### PR TITLE
Add video link field to lessons

### DIFF
--- a/navuchai_api/app/crud/lesson.py
+++ b/navuchai_api/app/crud/lesson.py
@@ -37,6 +37,7 @@ async def update_lesson(db: AsyncSession, lesson_id: int, data: LessonCreate):
     # Обновляем только те поля, которые действительно нужно менять.
     lesson.title = data.title
     lesson.content = data.content
+    lesson.video = data.video
     # НЕ переписываем lesson.order = data.order, иначе попадёт None и в БД будет ошибка.
 
     await db.commit()
@@ -78,6 +79,7 @@ async def create_lesson_for_module(
     new = Lesson(
         title=lesson_in.title,
         content=lesson_in.content,
+        video=lesson_in.video,
         order=new_order,
         module_id=module_id
     )

--- a/navuchai_api/app/models/lesson.py
+++ b/navuchai_api/app/models/lesson.py
@@ -8,6 +8,7 @@ class Lesson(Base):
     module_id = Column(Integer, ForeignKey('module.id'), nullable=False)
     title = Column(String, nullable=False)
     content = Column(Text)
+    video = Column(String)
     order = Column(Integer, default=0)
     module = relationship('Module', back_populates='lessons')
     tests = relationship('LessonTest', back_populates='lesson', cascade='all, delete-orphan')

--- a/navuchai_api/app/schemas/lesson.py
+++ b/navuchai_api/app/schemas/lesson.py
@@ -7,6 +7,7 @@ class LessonBase(BaseModel):
     module_id: int
     title: str
     content: Optional[str] = None
+    video: Optional[str] = None
     order: Optional[int] = None
     class Config:
         from_attributes = True
@@ -15,6 +16,7 @@ class LessonCreate(BaseModel):
     # module_id: int
     title: str
     content: Optional[str] = None
+    video: Optional[str] = None
     order: Optional[int] = None
 
 class LessonResponse(LessonBase):
@@ -31,6 +33,7 @@ class LessonRead(BaseModel):
     id: int
     title: str
     content: str
+    video: Optional[str] = None
     order: int
 
     model_config = {


### PR DESCRIPTION
## Summary
- support `video` link for lessons in data model and API
- allow creating modules with lesson videos

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684a975bda788322add998db13783502