### PR TITLE
Implement course/module/lesson access controls

### DIFF
--- a/navuchai_api/app/crud/course.py
+++ b/navuchai_api/app/crud/course.py
@@ -31,7 +31,12 @@ async def get_course(db: AsyncSession, course_id: int):
     return course
 
 async def create_course(db: AsyncSession, data: CourseCreate, author_id: int):
-    new_course = Course(title=data.title, description=data.description, author_id=author_id)
+    new_course = Course(
+        title=data.title,
+        description=data.description,
+        author_id=author_id,
+        access=data.access
+    )
     db.add(new_course)
     await db.commit()
     await db.refresh(new_course)
@@ -41,6 +46,7 @@ async def update_course(db: AsyncSession, course_id: int, data: CourseCreate):
     course = await get_course(db, course_id)
     course.title = data.title
     course.description = data.description
+    course.access = data.access
     await db.commit()
     await db.refresh(course)
     return course

--- a/navuchai_api/app/crud/course_access.py
+++ b/navuchai_api/app/crud/course_access.py
@@ -1,0 +1,123 @@
+from datetime import datetime
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from sqlalchemy.exc import SQLAlchemyError
+import secrets
+
+from app.models.course_access import CourseAccess
+from app.models.user_group_member import UserGroupMember
+from app.models.test_status import TestStatus
+from app.models.course import Course, TestAccessEnum
+from app.schemas.course_access import CourseAccessCreate
+from app.exceptions import DatabaseException, NotFoundException
+
+OPAQUE_TOKEN_NUM_BYTES = 16
+
+
+def _generate_access_code() -> str:
+    return secrets.token_urlsafe(OPAQUE_TOKEN_NUM_BYTES)
+
+
+async def create_course_access(db: AsyncSession, access_data: CourseAccessCreate) -> CourseAccess:
+    try:
+        course = await db.scalar(select(Course).where(Course.id == access_data.course_id))
+        if not course:
+            raise NotFoundException(f"Курс с ID {access_data.course_id} не найден")
+
+        data = access_data.model_dump(exclude_none=True)
+        data.pop('access_code', None)
+        db_access = CourseAccess(**data)
+
+        if access_data.user_id:
+            db_access.access_code = _generate_access_code()
+
+        db.add(db_access)
+        await db.commit()
+        await db.refresh(db_access)
+        return db_access
+    except SQLAlchemyError as e:
+        raise DatabaseException(f"Ошибка при создании доступа к курсу: {str(e)}")
+
+
+async def create_group_course_access(
+    db: AsyncSession,
+    course_id: int,
+    group_id: int,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    status_id: int | None = None
+) -> list[CourseAccess]:
+    try:
+        if status_id:
+            status = await db.scalar(select(TestStatus).where(TestStatus.id == status_id))
+            if not status:
+                raise NotFoundException(f"Статус с ID {status_id} не найден")
+
+        result = await db.execute(select(UserGroupMember).where(UserGroupMember.group_id == group_id))
+        members = result.scalars().all()
+        if not members:
+            raise NotFoundException(f"В группе с ID {group_id} нет пользователей")
+
+        created = []
+        for member in members:
+            payload = CourseAccessCreate(
+                course_id=course_id,
+                user_id=member.user_id,
+                group_id=group_id,
+                start_date=start_date,
+                end_date=end_date,
+                status_id=status_id
+            )
+            created_access = await create_course_access(db, payload)
+            created.append(created_access)
+        return created
+    except SQLAlchemyError:
+        raise DatabaseException("Ошибка при создании группового доступа к курсу")
+
+
+async def get_course_access(db: AsyncSession, course_id: int, user_id: int) -> CourseAccess:
+    try:
+        query = select(CourseAccess).where(
+            CourseAccess.course_id == course_id,
+            CourseAccess.user_id == user_id
+        ).options(selectinload(CourseAccess.status))
+        result = await db.execute(query)
+        return result.scalar_one_or_none()
+    except SQLAlchemyError:
+        raise DatabaseException("Ошибка при получении доступа к курсу")
+
+
+async def update_course_access(db: AsyncSession, course_id: int, access: str) -> Course:
+    try:
+        if access not in ['public', 'private']:
+            raise ValueError("Значение access должно быть 'public' или 'private'")
+
+        course = await db.scalar(select(Course).where(Course.id == course_id))
+        if not course:
+            raise NotFoundException(f"Курс с ID {course_id} не найден")
+
+        await db.execute(update(Course).where(Course.id == course_id).values(access=access))
+        await db.commit()
+        return await db.scalar(select(Course).where(Course.id == course_id))
+    except SQLAlchemyError:
+        raise DatabaseException("Ошибка при обновлении доступа к курсу")
+    except ValueError as e:
+        raise DatabaseException(str(e))
+
+
+async def get_course_access_code(db: AsyncSession, course_id: int, user_id: int) -> dict:
+    course = await db.scalar(select(Course).where(Course.id == course_id))
+    if not course:
+        raise NotFoundException(f"Курс с id {course_id} не найден")
+
+    if course.access == TestAccessEnum.PUBLIC:
+        return {"code": course.id}
+
+    access = await db.scalar(select(CourseAccess).where(
+        CourseAccess.course_id == course_id,
+        CourseAccess.user_id == user_id
+    ))
+    if not access:
+        raise NotFoundException(f"Доступ к курсу {course_id} для пользователя {user_id} не найден")
+    return {"access_code": access.access_code}

--- a/navuchai_api/app/crud/lesson.py
+++ b/navuchai_api/app/crud/lesson.py
@@ -38,6 +38,7 @@ async def update_lesson(db: AsyncSession, lesson_id: int, data: LessonCreate):
     lesson.title = data.title
     lesson.content = data.content
     lesson.video = data.video
+    lesson.access = data.access
     # НЕ переписываем lesson.order = data.order, иначе попадёт None и в БД будет ошибка.
 
     await db.commit()
@@ -81,7 +82,8 @@ async def create_lesson_for_module(
         content=lesson_in.content,
         video=lesson_in.video,
         order=new_order,
-        module_id=module_id
+        module_id=module_id,
+        access=lesson_in.access
     )
     db.add(new)
     await db.commit()

--- a/navuchai_api/app/crud/lesson_access.py
+++ b/navuchai_api/app/crud/lesson_access.py
@@ -1,0 +1,123 @@
+from datetime import datetime
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from sqlalchemy.exc import SQLAlchemyError
+import secrets
+
+from app.models.lesson_access import LessonAccess
+from app.models.user_group_member import UserGroupMember
+from app.models.test_status import TestStatus
+from app.models.lesson import Lesson, TestAccessEnum
+from app.schemas.lesson_access import LessonAccessCreate
+from app.exceptions import DatabaseException, NotFoundException
+
+OPAQUE_TOKEN_NUM_BYTES = 16
+
+
+def _generate_access_code() -> str:
+    return secrets.token_urlsafe(OPAQUE_TOKEN_NUM_BYTES)
+
+
+async def create_lesson_access(db: AsyncSession, access_data: LessonAccessCreate) -> LessonAccess:
+    try:
+        lesson = await db.scalar(select(Lesson).where(Lesson.id == access_data.lesson_id))
+        if not lesson:
+            raise NotFoundException(f"Урок с ID {access_data.lesson_id} не найден")
+
+        data = access_data.model_dump(exclude_none=True)
+        data.pop('access_code', None)
+        db_access = LessonAccess(**data)
+
+        if access_data.user_id:
+            db_access.access_code = _generate_access_code()
+
+        db.add(db_access)
+        await db.commit()
+        await db.refresh(db_access)
+        return db_access
+    except SQLAlchemyError as e:
+        raise DatabaseException(f"Ошибка при создании доступа к уроку: {str(e)}")
+
+
+async def create_group_lesson_access(
+    db: AsyncSession,
+    lesson_id: int,
+    group_id: int,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    status_id: int | None = None
+) -> list[LessonAccess]:
+    try:
+        if status_id:
+            status = await db.scalar(select(TestStatus).where(TestStatus.id == status_id))
+            if not status:
+                raise NotFoundException(f"Статус с ID {status_id} не найден")
+
+        result = await db.execute(select(UserGroupMember).where(UserGroupMember.group_id == group_id))
+        members = result.scalars().all()
+        if not members:
+            raise NotFoundException(f"В группе с ID {group_id} нет пользователей")
+
+        created = []
+        for member in members:
+            payload = LessonAccessCreate(
+                lesson_id=lesson_id,
+                user_id=member.user_id,
+                group_id=group_id,
+                start_date=start_date,
+                end_date=end_date,
+                status_id=status_id
+            )
+            created_access = await create_lesson_access(db, payload)
+            created.append(created_access)
+        return created
+    except SQLAlchemyError:
+        raise DatabaseException("Ошибка при создании группового доступа к уроку")
+
+
+async def get_lesson_access(db: AsyncSession, lesson_id: int, user_id: int) -> LessonAccess:
+    try:
+        query = select(LessonAccess).where(
+            LessonAccess.lesson_id == lesson_id,
+            LessonAccess.user_id == user_id
+        ).options(selectinload(LessonAccess.status))
+        result = await db.execute(query)
+        return result.scalar_one_or_none()
+    except SQLAlchemyError:
+        raise DatabaseException("Ошибка при получении доступа к уроку")
+
+
+async def update_lesson_access(db: AsyncSession, lesson_id: int, access: str) -> Lesson:
+    try:
+        if access not in ['public', 'private']:
+            raise ValueError("Значение access должно быть 'public' или 'private'")
+
+        lesson = await db.scalar(select(Lesson).where(Lesson.id == lesson_id))
+        if not lesson:
+            raise NotFoundException(f"Урок с ID {lesson_id} не найден")
+
+        await db.execute(update(Lesson).where(Lesson.id == lesson_id).values(access=access))
+        await db.commit()
+        return await db.scalar(select(Lesson).where(Lesson.id == lesson_id))
+    except SQLAlchemyError:
+        raise DatabaseException("Ошибка при обновлении доступа к уроку")
+    except ValueError as e:
+        raise DatabaseException(str(e))
+
+
+async def get_lesson_access_code(db: AsyncSession, lesson_id: int, user_id: int) -> dict:
+    lesson = await db.scalar(select(Lesson).where(Lesson.id == lesson_id))
+    if not lesson:
+        raise NotFoundException(f"Урок с id {lesson_id} не найден")
+
+    if lesson.access == TestAccessEnum.PUBLIC:
+        return {"code": lesson.id}
+
+    access = await db.scalar(select(LessonAccess).where(
+        LessonAccess.lesson_id == lesson_id,
+        LessonAccess.user_id == user_id
+    ))
+    if not access:
+        raise NotFoundException(f"Доступ к уроку {lesson_id} для пользователя {user_id} не найден")
+    return {"access_code": access.access_code}

--- a/navuchai_api/app/crud/module.py
+++ b/navuchai_api/app/crud/module.py
@@ -35,6 +35,7 @@ async def update_module(db: AsyncSession, module_id: int, data):
     module = await get_module(db, module_id)
     module.title = data.title
     # Не заменяем module.order, чтобы он не стал None
+    module.access = data.access
 
     await db.commit()
     await db.refresh(module)
@@ -84,7 +85,8 @@ async def create_module_for_course(db: AsyncSession, course_id: int, module_in):
     new = Module(
         title=module_in.title,
         order=new_order,
-        course_id=course_id
+        course_id=course_id,
+        access=module_in.access
     )
     db.add(new)
     await db.commit()

--- a/navuchai_api/app/crud/module_access.py
+++ b/navuchai_api/app/crud/module_access.py
@@ -1,0 +1,123 @@
+from datetime import datetime
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from sqlalchemy.exc import SQLAlchemyError
+import secrets
+
+from app.models.module_access import ModuleAccess
+from app.models.user_group_member import UserGroupMember
+from app.models.test_status import TestStatus
+from app.models.module import Module, TestAccessEnum
+from app.schemas.module_access import ModuleAccessCreate
+from app.exceptions import DatabaseException, NotFoundException
+
+OPAQUE_TOKEN_NUM_BYTES = 16
+
+
+def _generate_access_code() -> str:
+    return secrets.token_urlsafe(OPAQUE_TOKEN_NUM_BYTES)
+
+
+async def create_module_access(db: AsyncSession, access_data: ModuleAccessCreate) -> ModuleAccess:
+    try:
+        module = await db.scalar(select(Module).where(Module.id == access_data.module_id))
+        if not module:
+            raise NotFoundException(f"Модуль с ID {access_data.module_id} не найден")
+
+        data = access_data.model_dump(exclude_none=True)
+        data.pop('access_code', None)
+        db_access = ModuleAccess(**data)
+
+        if access_data.user_id:
+            db_access.access_code = _generate_access_code()
+
+        db.add(db_access)
+        await db.commit()
+        await db.refresh(db_access)
+        return db_access
+    except SQLAlchemyError as e:
+        raise DatabaseException(f"Ошибка при создании доступа к модулю: {str(e)}")
+
+
+async def create_group_module_access(
+    db: AsyncSession,
+    module_id: int,
+    group_id: int,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    status_id: int | None = None
+) -> list[ModuleAccess]:
+    try:
+        if status_id:
+            status = await db.scalar(select(TestStatus).where(TestStatus.id == status_id))
+            if not status:
+                raise NotFoundException(f"Статус с ID {status_id} не найден")
+
+        result = await db.execute(select(UserGroupMember).where(UserGroupMember.group_id == group_id))
+        members = result.scalars().all()
+        if not members:
+            raise NotFoundException(f"В группе с ID {group_id} нет пользователей")
+
+        created = []
+        for member in members:
+            payload = ModuleAccessCreate(
+                module_id=module_id,
+                user_id=member.user_id,
+                group_id=group_id,
+                start_date=start_date,
+                end_date=end_date,
+                status_id=status_id
+            )
+            created_access = await create_module_access(db, payload)
+            created.append(created_access)
+        return created
+    except SQLAlchemyError:
+        raise DatabaseException("Ошибка при создании группового доступа к модулю")
+
+
+async def get_module_access(db: AsyncSession, module_id: int, user_id: int) -> ModuleAccess:
+    try:
+        query = select(ModuleAccess).where(
+            ModuleAccess.module_id == module_id,
+            ModuleAccess.user_id == user_id
+        ).options(selectinload(ModuleAccess.status))
+        result = await db.execute(query)
+        return result.scalar_one_or_none()
+    except SQLAlchemyError:
+        raise DatabaseException("Ошибка при получении доступа к модулю")
+
+
+async def update_module_access(db: AsyncSession, module_id: int, access: str) -> Module:
+    try:
+        if access not in ['public', 'private']:
+            raise ValueError("Значение access должно быть 'public' или 'private'")
+
+        module = await db.scalar(select(Module).where(Module.id == module_id))
+        if not module:
+            raise NotFoundException(f"Модуль с ID {module_id} не найден")
+
+        await db.execute(update(Module).where(Module.id == module_id).values(access=access))
+        await db.commit()
+        return await db.scalar(select(Module).where(Module.id == module_id))
+    except SQLAlchemyError:
+        raise DatabaseException("Ошибка при обновлении доступа к модулю")
+    except ValueError as e:
+        raise DatabaseException(str(e))
+
+
+async def get_module_access_code(db: AsyncSession, module_id: int, user_id: int) -> dict:
+    module = await db.scalar(select(Module).where(Module.id == module_id))
+    if not module:
+        raise NotFoundException(f"Модуль с id {module_id} не найден")
+
+    if module.access == TestAccessEnum.PUBLIC:
+        return {"code": module.id}
+
+    access = await db.scalar(select(ModuleAccess).where(
+        ModuleAccess.module_id == module_id,
+        ModuleAccess.user_id == user_id
+    ))
+    if not access:
+        raise NotFoundException(f"Доступ к модулю {module_id} для пользователя {user_id} не найден")
+    return {"access_code": access.access_code}

--- a/navuchai_api/app/main.py
+++ b/navuchai_api/app/main.py
@@ -5,7 +5,8 @@ from app.models import Base
 from app.routes import (
     tests, questions, user, auth, profile,
     category, locale, files, role, user_groups,
-    test_access, test_status, results
+    test_access, test_status, results,
+    course_access, module_access, lesson_access
 )
 from fastapi.middleware.cors import CORSMiddleware
 from app.routes import courses, modules, lessons, enrollment
@@ -34,6 +35,9 @@ app.include_router(user_groups.router)
 app.include_router(test_access.router)
 app.include_router(test_status.router)
 app.include_router(results.router)
+app.include_router(course_access.router)
+app.include_router(module_access.router)
+app.include_router(lesson_access.router)
 app.include_router(courses.router)
 app.include_router(modules.router)
 app.include_router(lessons.router)

--- a/navuchai_api/app/models/__init__.py
+++ b/navuchai_api/app/models/__init__.py
@@ -5,6 +5,8 @@ from .course import Course
 from .module import Module
 from .lesson import Lesson
 from .lesson_test import LessonTest
+from .course_test import CourseTest
+from .module_test import ModuleTest
 from .course_enrollment import CourseEnrollment
 from .test import Test
 from .question import Question
@@ -18,6 +20,9 @@ from .test_status import TestStatus
 from .user_group import UserGroup
 from .user_group_member import UserGroupMember
 from .test_access import TestAccess
+from .course_access import CourseAccess
+from .module_access import ModuleAccess
+from .lesson_access import LessonAccess
 
 __all__ = [
     "Base",
@@ -34,14 +39,11 @@ __all__ = [
     "TestStatus",
     "UserGroup",
     "UserGroupMember",
-    "TestAccess"
+    "TestAccess",
+    "CourseAccess",
+    "ModuleAccess",
+    "LessonAccess",
+    "CourseTest",
+    "ModuleTest",
 ]
-from .result import Result
-from .base import Base
-from .role import Role
-from .course import Course
-from .module import Module
-from .lesson import Lesson
-from .lesson_test import LessonTest
-from .course_enrollment import CourseEnrollment
 

--- a/navuchai_api/app/models/course.py
+++ b/navuchai_api/app/models/course.py
@@ -1,7 +1,8 @@
-from sqlalchemy import Column, Integer, String, Text, ForeignKey, TIMESTAMP
+from sqlalchemy import Column, Integer, String, Text, ForeignKey, TIMESTAMP, Enum
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
 from app.models.base import Base
+from app.models.test import TestAccessEnum
 
 class Course(Base):
     __tablename__ = 'course'
@@ -10,6 +11,11 @@ class Course(Base):
     description = Column(Text)
     author_id = Column(Integer, ForeignKey('user.id'), nullable=False)
     created_at = Column(TIMESTAMP, nullable=False, server_default=func.now())
+    access = Column(Enum(TestAccessEnum, name='course_access_enum', create_type=False,
+                        values_callable=lambda obj: [e.value for e in obj]),
+                    nullable=False, default=TestAccessEnum.PRIVATE)
     author = relationship('User')
     modules = relationship('Module', back_populates='course', cascade='all, delete-orphan')
     enrollments = relationship('CourseEnrollment', back_populates='course', cascade='all, delete-orphan')
+    course_accesses = relationship('CourseAccess', back_populates='course', cascade='all, delete-orphan')
+    tests = relationship('CourseTest', back_populates='course', cascade='all, delete-orphan')

--- a/navuchai_api/app/models/course_access.py
+++ b/navuchai_api/app/models/course_access.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Column, Integer, DateTime, ForeignKey, TIMESTAMP, String
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+from app.models.base import Base
+
+
+class CourseAccess(Base):
+    """Модель доступа к курсу"""
+    __tablename__ = "course_access"
+
+    id = Column(Integer, primary_key=True, index=True)
+    course_id = Column(Integer, ForeignKey("course.id", ondelete="CASCADE"), nullable=False)
+    user_id = Column(Integer, ForeignKey("user.id", ondelete="CASCADE"), nullable=False)
+    group_id = Column(Integer, ForeignKey("user_group.id", ondelete="CASCADE"))
+    start_date = Column(DateTime)
+    end_date = Column(DateTime)
+    status_id = Column(Integer, ForeignKey("test_status.id"))
+    created_at = Column(TIMESTAMP, nullable=False, server_default=func.now())
+    updated_at = Column(TIMESTAMP, nullable=False, server_default=func.now())
+    access_code = Column(String, nullable=True, unique=True, index=True)
+
+    course = relationship("Course", back_populates="course_accesses")
+    user = relationship("User")
+    group = relationship("UserGroup")
+    status = relationship("TestStatus")

--- a/navuchai_api/app/models/course_test.py
+++ b/navuchai_api/app/models/course_test.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, Boolean, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import relationship
+from app.models.base import Base
+
+
+class CourseTest(Base):
+    __tablename__ = 'course_test'
+    id = Column(Integer, primary_key=True, index=True)
+    course_id = Column(Integer, ForeignKey('course.id'), nullable=False)
+    test_id = Column(Integer, ForeignKey('test.id'), nullable=False)
+    required = Column(Boolean, default=True)
+    course = relationship('Course', back_populates='tests')
+    test = relationship('Test')
+    __table_args__ = (UniqueConstraint('course_id', 'test_id', name='course_test_unique'),)

--- a/navuchai_api/app/models/lesson.py
+++ b/navuchai_api/app/models/lesson.py
@@ -1,6 +1,7 @@
-from sqlalchemy import Column, Integer, String, Text, ForeignKey
+from sqlalchemy import Column, Integer, String, Text, ForeignKey, Enum
 from sqlalchemy.orm import relationship
 from app.models.base import Base
+from app.models.test import TestAccessEnum
 
 class Lesson(Base):
     __tablename__ = 'lesson'
@@ -10,5 +11,9 @@ class Lesson(Base):
     content = Column(Text)
     video = Column(String)
     order = Column(Integer, default=0)
+    access = Column(Enum(TestAccessEnum, name='lesson_access_enum', create_type=False,
+                        values_callable=lambda obj: [e.value for e in obj]),
+                    nullable=False, default=TestAccessEnum.PRIVATE)
     module = relationship('Module', back_populates='lessons')
     tests = relationship('LessonTest', back_populates='lesson', cascade='all, delete-orphan')
+    lesson_accesses = relationship('LessonAccess', back_populates='lesson', cascade='all, delete-orphan')

--- a/navuchai_api/app/models/lesson_access.py
+++ b/navuchai_api/app/models/lesson_access.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Column, Integer, DateTime, ForeignKey, TIMESTAMP, String
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+from app.models.base import Base
+
+
+class LessonAccess(Base):
+    """Модель доступа к уроку"""
+    __tablename__ = "lesson_access"
+
+    id = Column(Integer, primary_key=True, index=True)
+    lesson_id = Column(Integer, ForeignKey("lesson.id", ondelete="CASCADE"), nullable=False)
+    user_id = Column(Integer, ForeignKey("user.id", ondelete="CASCADE"), nullable=False)
+    group_id = Column(Integer, ForeignKey("user_group.id", ondelete="CASCADE"))
+    start_date = Column(DateTime)
+    end_date = Column(DateTime)
+    status_id = Column(Integer, ForeignKey("test_status.id"))
+    created_at = Column(TIMESTAMP, nullable=False, server_default=func.now())
+    updated_at = Column(TIMESTAMP, nullable=False, server_default=func.now())
+    access_code = Column(String, nullable=True, unique=True, index=True)
+
+    lesson = relationship("Lesson", back_populates="lesson_accesses")
+    user = relationship("User")
+    group = relationship("UserGroup")
+    status = relationship("TestStatus")

--- a/navuchai_api/app/models/module.py
+++ b/navuchai_api/app/models/module.py
@@ -1,6 +1,7 @@
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, Integer, String, ForeignKey, Enum
 from sqlalchemy.orm import relationship
 from app.models.base import Base
+from app.models.test import TestAccessEnum
 
 class Module(Base):
     __tablename__ = 'module'
@@ -8,5 +9,10 @@ class Module(Base):
     course_id = Column(Integer, ForeignKey('course.id'), nullable=False)
     title = Column(String, nullable=False)
     order = Column(Integer, default=0)
+    access = Column(Enum(TestAccessEnum, name='module_access_enum', create_type=False,
+                        values_callable=lambda obj: [e.value for e in obj]),
+                    nullable=False, default=TestAccessEnum.PRIVATE)
     course = relationship('Course', back_populates='modules')
     lessons = relationship('Lesson', back_populates='module', cascade='all, delete-orphan')
+    module_accesses = relationship('ModuleAccess', back_populates='module', cascade='all, delete-orphan')
+    tests = relationship('ModuleTest', back_populates='module', cascade='all, delete-orphan')

--- a/navuchai_api/app/models/module_access.py
+++ b/navuchai_api/app/models/module_access.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Column, Integer, DateTime, ForeignKey, TIMESTAMP, String
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+from app.models.base import Base
+
+
+class ModuleAccess(Base):
+    """Модель доступа к модулю"""
+    __tablename__ = "module_access"
+
+    id = Column(Integer, primary_key=True, index=True)
+    module_id = Column(Integer, ForeignKey("module.id", ondelete="CASCADE"), nullable=False)
+    user_id = Column(Integer, ForeignKey("user.id", ondelete="CASCADE"), nullable=False)
+    group_id = Column(Integer, ForeignKey("user_group.id", ondelete="CASCADE"))
+    start_date = Column(DateTime)
+    end_date = Column(DateTime)
+    status_id = Column(Integer, ForeignKey("test_status.id"))
+    created_at = Column(TIMESTAMP, nullable=False, server_default=func.now())
+    updated_at = Column(TIMESTAMP, nullable=False, server_default=func.now())
+    access_code = Column(String, nullable=True, unique=True, index=True)
+
+    module = relationship("Module", back_populates="module_accesses")
+    user = relationship("User")
+    group = relationship("UserGroup")
+    status = relationship("TestStatus")

--- a/navuchai_api/app/models/module_test.py
+++ b/navuchai_api/app/models/module_test.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, Boolean, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import relationship
+from app.models.base import Base
+
+
+class ModuleTest(Base):
+    __tablename__ = 'module_test'
+    id = Column(Integer, primary_key=True, index=True)
+    module_id = Column(Integer, ForeignKey('module.id'), nullable=False)
+    test_id = Column(Integer, ForeignKey('test.id'), nullable=False)
+    required = Column(Boolean, default=True)
+    module = relationship('Module', back_populates='tests')
+    test = relationship('Test')
+    __table_args__ = (UniqueConstraint('module_id', 'test_id', name='module_test_unique'),)

--- a/navuchai_api/app/routes/course_access.py
+++ b/navuchai_api/app/routes/course_access.py
@@ -1,0 +1,83 @@
+from typing import List
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from datetime import datetime
+
+from app.dependencies import get_db
+from app.crud import admin_moderator_required
+from app.crud import course_access as crud
+from app.models.user import User
+from app.schemas.course_access import CourseAccessCreate, CourseAccessResponse
+from app.schemas.course import CourseResponse
+from app.exceptions import DatabaseException, NotFoundException
+
+router = APIRouter(prefix="/api/course-access", tags=["Course Access"])
+
+
+@router.post("/user", response_model=CourseAccessResponse)
+async def create_user_course_access(
+    course_access: CourseAccessCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(admin_moderator_required)
+) -> CourseAccessResponse:
+    try:
+        if course_access.group_id is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="Для предоставления доступа группе используйте endpoint /group"
+            )
+
+        existing = await crud.get_course_access(db, course_access.course_id, course_access.user_id)
+        if existing:
+            raise HTTPException(status_code=400, detail="У пользователя уже есть доступ к этому курсу")
+        return await crud.create_course_access(db, course_access)
+    except (DatabaseException, NotFoundException) as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/group", response_model=List[CourseAccessResponse])
+async def create_group_course_access(
+    course_id: int,
+    group_id: int,
+    start_date: datetime = None,
+    end_date: datetime = None,
+    status_id: int = None,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(admin_moderator_required)
+) -> List[CourseAccessResponse]:
+    try:
+        return await crud.create_group_course_access(
+            db=db,
+            course_id=course_id,
+            group_id=group_id,
+            start_date=start_date,
+            end_date=end_date,
+            status_id=status_id
+        )
+    except (DatabaseException, NotFoundException) as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.put("/{course_id}/access", response_model=CourseResponse)
+async def update_course_access_type(
+    course_id: int,
+    access: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(admin_moderator_required)
+) -> CourseResponse:
+    try:
+        return await crud.update_course_access(db, course_id, access)
+    except (DatabaseException, NotFoundException) as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/{course_id}/code", response_model=dict)
+async def get_course_access_code(
+    course_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(admin_moderator_required)
+) -> dict:
+    try:
+        return await crud.get_course_access_code(db, course_id, current_user.id)
+    except (DatabaseException, NotFoundException) as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/navuchai_api/app/routes/lesson_access.py
+++ b/navuchai_api/app/routes/lesson_access.py
@@ -1,0 +1,83 @@
+from typing import List
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from datetime import datetime
+
+from app.dependencies import get_db
+from app.crud import admin_moderator_required
+from app.crud import lesson_access as crud
+from app.models.user import User
+from app.schemas.lesson_access import LessonAccessCreate, LessonAccessResponse
+from app.schemas.lesson import LessonWithTests
+from app.exceptions import DatabaseException, NotFoundException
+
+router = APIRouter(prefix="/api/lesson-access", tags=["Lesson Access"])
+
+
+@router.post("/user", response_model=LessonAccessResponse)
+async def create_user_lesson_access(
+    lesson_access: LessonAccessCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(admin_moderator_required)
+) -> LessonAccessResponse:
+    try:
+        if lesson_access.group_id is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="Для предоставления доступа группе используйте endpoint /group"
+            )
+
+        existing = await crud.get_lesson_access(db, lesson_access.lesson_id, lesson_access.user_id)
+        if existing:
+            raise HTTPException(status_code=400, detail="У пользователя уже есть доступ к этому уроку")
+        return await crud.create_lesson_access(db, lesson_access)
+    except (DatabaseException, NotFoundException) as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/group", response_model=List[LessonAccessResponse])
+async def create_group_lesson_access(
+    lesson_id: int,
+    group_id: int,
+    start_date: datetime = None,
+    end_date: datetime = None,
+    status_id: int = None,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(admin_moderator_required)
+) -> List[LessonAccessResponse]:
+    try:
+        return await crud.create_group_lesson_access(
+            db=db,
+            lesson_id=lesson_id,
+            group_id=group_id,
+            start_date=start_date,
+            end_date=end_date,
+            status_id=status_id
+        )
+    except (DatabaseException, NotFoundException) as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.put("/{lesson_id}/access", response_model=LessonWithTests)
+async def update_lesson_access_type(
+    lesson_id: int,
+    access: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(admin_moderator_required)
+) -> LessonWithTests:
+    try:
+        return await crud.update_lesson_access(db, lesson_id, access)
+    except (DatabaseException, NotFoundException) as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/{lesson_id}/code", response_model=dict)
+async def get_lesson_access_code(
+    lesson_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(admin_moderator_required)
+) -> dict:
+    try:
+        return await crud.get_lesson_access_code(db, lesson_id, current_user.id)
+    except (DatabaseException, NotFoundException) as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/navuchai_api/app/routes/module_access.py
+++ b/navuchai_api/app/routes/module_access.py
@@ -1,0 +1,83 @@
+from typing import List
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from datetime import datetime
+
+from app.dependencies import get_db
+from app.crud import admin_moderator_required
+from app.crud import module_access as crud
+from app.models.user import User
+from app.schemas.module_access import ModuleAccessCreate, ModuleAccessResponse
+from app.schemas.module import ModuleWithLessons
+from app.exceptions import DatabaseException, NotFoundException
+
+router = APIRouter(prefix="/api/module-access", tags=["Module Access"])
+
+
+@router.post("/user", response_model=ModuleAccessResponse)
+async def create_user_module_access(
+    module_access: ModuleAccessCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(admin_moderator_required)
+) -> ModuleAccessResponse:
+    try:
+        if module_access.group_id is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="Для предоставления доступа группе используйте endpoint /group"
+            )
+
+        existing = await crud.get_module_access(db, module_access.module_id, module_access.user_id)
+        if existing:
+            raise HTTPException(status_code=400, detail="У пользователя уже есть доступ к этому модулю")
+        return await crud.create_module_access(db, module_access)
+    except (DatabaseException, NotFoundException) as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/group", response_model=List[ModuleAccessResponse])
+async def create_group_module_access(
+    module_id: int,
+    group_id: int,
+    start_date: datetime = None,
+    end_date: datetime = None,
+    status_id: int = None,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(admin_moderator_required)
+) -> List[ModuleAccessResponse]:
+    try:
+        return await crud.create_group_module_access(
+            db=db,
+            module_id=module_id,
+            group_id=group_id,
+            start_date=start_date,
+            end_date=end_date,
+            status_id=status_id
+        )
+    except (DatabaseException, NotFoundException) as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.put("/{module_id}/access", response_model=ModuleWithLessons)
+async def update_module_access_type(
+    module_id: int,
+    access: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(admin_moderator_required)
+) -> ModuleWithLessons:
+    try:
+        return await crud.update_module_access(db, module_id, access)
+    except (DatabaseException, NotFoundException) as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/{module_id}/code", response_model=dict)
+async def get_module_access_code(
+    module_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(admin_moderator_required)
+) -> dict:
+    try:
+        return await crud.get_module_access_code(db, module_id, current_user.id)
+    except (DatabaseException, NotFoundException) as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/navuchai_api/app/schemas/course.py
+++ b/navuchai_api/app/schemas/course.py
@@ -3,6 +3,7 @@ from typing import Optional, List
 from pydantic import BaseModel
 from app.schemas.module import ModuleBase
 from .module import ModuleRead
+from app.models.test import TestAccessEnum
 
 class CourseBase(BaseModel):
     id: int
@@ -10,12 +11,14 @@ class CourseBase(BaseModel):
     description: Optional[str] = None
     author_id: int
     created_at: datetime
+    access: TestAccessEnum
     class Config:
         from_attributes = True
 
 class CourseCreate(BaseModel):
     title: str
     description: Optional[str] = None
+    access: TestAccessEnum = TestAccessEnum.PRIVATE
 
 class CourseResponse(CourseBase):
     pass
@@ -30,6 +33,7 @@ class CourseRead(BaseModel):
     title: str
     description: str
     modules: List[ModuleRead]
+    access: TestAccessEnum
 
     model_config = {
         "from_attributes": True

--- a/navuchai_api/app/schemas/course_access.py
+++ b/navuchai_api/app/schemas/course_access.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel
+
+
+class CourseAccessBase(BaseModel):
+    course_id: int
+    user_id: Optional[int] = None
+    group_id: Optional[int] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+    status_id: Optional[int] = None
+    access_code: Optional[str] = None
+
+
+class CourseAccessCreate(BaseModel):
+    course_id: int
+    user_id: Optional[int] = None
+    group_id: Optional[int] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+    status_id: Optional[int] = None
+    access_code: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class CourseAccessResponse(BaseModel):
+    id: int
+    course_id: int
+    user_id: int
+    group_id: Optional[int] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+    status_id: Optional[int] = None
+    status_name: Optional[str] = None
+    access_code: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/navuchai_api/app/schemas/lesson.py
+++ b/navuchai_api/app/schemas/lesson.py
@@ -1,6 +1,7 @@
 from typing import Optional, List
 from app.schemas.lesson_test import LessonTestBase
 from pydantic import BaseModel
+from app.models.test import TestAccessEnum
 
 class LessonBase(BaseModel):
     id: int
@@ -9,6 +10,7 @@ class LessonBase(BaseModel):
     content: Optional[str] = None
     video: Optional[str] = None
     order: Optional[int] = None
+    access: TestAccessEnum
     class Config:
         from_attributes = True
 
@@ -18,6 +20,7 @@ class LessonCreate(BaseModel):
     content: Optional[str] = None
     video: Optional[str] = None
     order: Optional[int] = None
+    access: TestAccessEnum = TestAccessEnum.PRIVATE
 
 class LessonResponse(LessonBase):
     pass
@@ -35,6 +38,7 @@ class LessonRead(BaseModel):
     content: str
     video: Optional[str] = None
     order: int
+    access: TestAccessEnum
 
     model_config = {
         "from_attributes": True

--- a/navuchai_api/app/schemas/lesson_access.py
+++ b/navuchai_api/app/schemas/lesson_access.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel
+
+
+class LessonAccessBase(BaseModel):
+    lesson_id: int
+    user_id: Optional[int] = None
+    group_id: Optional[int] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+    status_id: Optional[int] = None
+    access_code: Optional[str] = None
+
+
+class LessonAccessCreate(BaseModel):
+    lesson_id: int
+    user_id: Optional[int] = None
+    group_id: Optional[int] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+    status_id: Optional[int] = None
+    access_code: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class LessonAccessResponse(BaseModel):
+    id: int
+    lesson_id: int
+    user_id: int
+    group_id: Optional[int] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+    status_id: Optional[int] = None
+    status_name: Optional[str] = None
+    access_code: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/navuchai_api/app/schemas/module.py
+++ b/navuchai_api/app/schemas/module.py
@@ -2,17 +2,20 @@ from typing import Optional, List
 from pydantic import BaseModel
 from app.schemas.lesson import LessonBase
 from .lesson import LessonRead
+from app.models.test import TestAccessEnum
 
 class ModuleBase(BaseModel):
     id: int
     course_id: int
     title: str
     order: Optional[int] = None
+    access: TestAccessEnum
     class Config:
         from_attributes = True
 
 class ModuleCreate(BaseModel):
     title: str
+    access: TestAccessEnum = TestAccessEnum.PRIVATE
 
 class ModuleWithLessons(ModuleBase):
     lessons: List['LessonBase'] = []
@@ -23,6 +26,7 @@ class ModuleRead(BaseModel):
     id: int
     title: str
     order: int
+    access: TestAccessEnum
     lessons: List[LessonRead]
 
     model_config = {
@@ -32,6 +36,7 @@ class ModuleRead(BaseModel):
 class ModuleResponse(BaseModel):
     title: str
     order: Optional[int] = None
+    access: TestAccessEnum = TestAccessEnum.PRIVATE
 
     class Config:
         orm_mode = True

--- a/navuchai_api/app/schemas/module_access.py
+++ b/navuchai_api/app/schemas/module_access.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel
+
+
+class ModuleAccessBase(BaseModel):
+    module_id: int
+    user_id: Optional[int] = None
+    group_id: Optional[int] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+    status_id: Optional[int] = None
+    access_code: Optional[str] = None
+
+
+class ModuleAccessCreate(BaseModel):
+    module_id: int
+    user_id: Optional[int] = None
+    group_id: Optional[int] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+    status_id: Optional[int] = None
+    access_code: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class ModuleAccessResponse(BaseModel):
+    id: int
+    module_id: int
+    user_id: int
+    group_id: Optional[int] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+    status_id: Optional[int] = None
+    status_name: Optional[str] = None
+    access_code: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True


### PR DESCRIPTION
## Summary
- add enum-based `access` fields to course, module and lesson models
- create access models and CRUD for courses, modules and lessons
- support new access schema objects
- map tests to courses and modules
- wire new access routers in the application

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6851c6e8e90c832285e5fd1e56da466d