### PR TITLE
Add course and lesson progress tracking

### DIFF
--- a/navuchai_api/app/crud/__init__.py
+++ b/navuchai_api/app/crud/__init__.py
@@ -8,5 +8,5 @@ from .user import get_users, get_user, update_user, delete_user, update_user_rol
 from .user_auth import get_current_user
 from .course import get_courses, get_course, create_course, update_course, delete_course, get_course_with_content
 from .module import create_module, get_module, update_module, delete_module, get_modules_by_course, get_modules_with_lessons_by_course, create_module_for_course
-from .lesson import create_lesson, get_lesson, update_lesson, delete_lesson, get_lessons_by_module, create_lesson_for_module
-from .enrollment import enroll_user, unenroll_user, get_user_courses
+from .lesson import create_lesson, get_lesson, update_lesson, delete_lesson, get_lessons_by_module, create_lesson_for_module, complete_lesson, get_module_progress, get_course_progress
+from .enrollment import enroll_user, unenroll_user, get_user_courses, user_enrolled

--- a/navuchai_api/app/crud/enrollment.py
+++ b/navuchai_api/app/crud/enrollment.py
@@ -25,3 +25,12 @@ async def unenroll_user(db: AsyncSession, course_id: int, user_id: int):
 async def get_user_courses(db: AsyncSession, user_id: int):
     result = await db.execute(select(CourseEnrollment).where(CourseEnrollment.user_id == user_id))
     return result.scalars().all()
+
+
+async def user_enrolled(db: AsyncSession, course_id: int, user_id: int) -> bool:
+    result = await db.execute(
+        select(CourseEnrollment).where(
+            and_(CourseEnrollment.course_id == course_id, CourseEnrollment.user_id == user_id)
+        )
+    )
+    return result.scalar_one_or_none() is not None

--- a/navuchai_api/app/crud/module.py
+++ b/navuchai_api/app/crud/module.py
@@ -34,6 +34,7 @@ async def update_module(db: AsyncSession, module_id: int, data):
 
     module = await get_module(db, module_id)
     module.title = data.title
+    module.description = data.description
     # Не заменяем module.order, чтобы он не стал None
 
     await db.commit()
@@ -83,6 +84,7 @@ async def create_module_for_course(db: AsyncSession, course_id: int, module_in):
 
     new = Module(
         title=module_in.title,
+        description=module_in.description,
         order=new_order,
         course_id=course_id
     )

--- a/navuchai_api/app/models/__init__.py
+++ b/navuchai_api/app/models/__init__.py
@@ -6,6 +6,7 @@ from .module import Module
 from .lesson import Lesson
 from .lesson_test import LessonTest
 from .course_enrollment import CourseEnrollment
+from .lesson_progress import LessonProgress
 from .test import Test
 from .question import Question
 from .test_question import TestQuestion
@@ -28,6 +29,9 @@ __all__ = [
     "Test",
     "Question",
     "TestQuestion",
+    "Course",
+    "Module",
+    "Lesson",
     "Category",
     "Locale",
     "File",
@@ -38,6 +42,8 @@ __all__ = [
     "UserGroupMember",
     "TestAccess",
     "QuestionType",
-    "TestAccessStatus"
+    "TestAccessStatus",
+    "CourseEnrollment",
+    "LessonProgress"
 ]
 

--- a/navuchai_api/app/models/lesson.py
+++ b/navuchai_api/app/models/lesson.py
@@ -1,14 +1,27 @@
-from sqlalchemy import Column, Integer, String, Text, ForeignKey
+from sqlalchemy import Column, Integer, String, Text, ForeignKey, Table
 from sqlalchemy.orm import relationship
+from app.models.lesson_progress import LessonProgress
 from app.models.base import Base
+from app.models.file import File
+
+# Association table for lesson files (images or videos)
+lesson_files = Table(
+    "lesson_files",
+    Base.metadata,
+    Column("lesson_id", Integer, ForeignKey("lesson.id", ondelete="CASCADE"), primary_key=True),
+    Column("file_id", Integer, ForeignKey("file.id", ondelete="CASCADE"), primary_key=True)
+)
 
 class Lesson(Base):
     __tablename__ = 'lesson'
     id = Column(Integer, primary_key=True, index=True)
     module_id = Column(Integer, ForeignKey('module.id'), nullable=False)
     title = Column(String, nullable=False)
+    description = Column(Text)
     content = Column(Text)
     video = Column(String)
     order = Column(Integer, default=0)
     module = relationship('Module', back_populates='lessons')
     tests = relationship('LessonTest', back_populates='lesson', cascade='all, delete-orphan')
+    progress = relationship('LessonProgress', back_populates='lesson', cascade='all, delete-orphan')
+    files = relationship('File', secondary=lesson_files, lazy='selectin')

--- a/navuchai_api/app/models/lesson_progress.py
+++ b/navuchai_api/app/models/lesson_progress.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, Integer, TIMESTAMP, ForeignKey, UniqueConstraint
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+from app.models.base import Base
+
+class LessonProgress(Base):
+    __tablename__ = 'lesson_progress'
+
+    id = Column(Integer, primary_key=True, index=True)
+    lesson_id = Column(Integer, ForeignKey('lesson.id', ondelete='CASCADE'), nullable=False)
+    user_id = Column(Integer, ForeignKey('user.id', ondelete='CASCADE'), nullable=False)
+    completed_at = Column(TIMESTAMP, nullable=False, server_default=func.now())
+
+    lesson = relationship('Lesson', back_populates='progress')
+    user = relationship('User')
+
+    __table_args__ = (UniqueConstraint('lesson_id', 'user_id', name='lesson_user_unique'),)

--- a/navuchai_api/app/models/module.py
+++ b/navuchai_api/app/models/module.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, Integer, String, ForeignKey, Text
 from sqlalchemy.orm import relationship
 from app.models.base import Base
 
@@ -7,6 +7,7 @@ class Module(Base):
     id = Column(Integer, primary_key=True, index=True)
     course_id = Column(Integer, ForeignKey('course.id'), nullable=False)
     title = Column(String, nullable=False)
+    description = Column(Text)
     order = Column(Integer, default=0)
     course = relationship('Course', back_populates='modules')
     lessons = relationship('Lesson', back_populates='module', cascade='all, delete-orphan')

--- a/navuchai_api/app/routes/modules.py
+++ b/navuchai_api/app/routes/modules.py
@@ -1,10 +1,22 @@
 from fastapi import APIRouter, Depends, status, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies import get_db
-from app.crud import create_module, get_module, update_module, delete_module, admin_moderator_required, get_lessons_by_module, create_lesson_for_module
+from app.crud import (
+    create_module,
+    get_module,
+    update_module,
+    delete_module,
+    admin_moderator_required,
+    get_lessons_by_module,
+    create_lesson_for_module,
+    get_module_progress,
+    user_enrolled,
+    complete_lesson,
+)
 from app.schemas.module import ModuleCreate, ModuleWithLessons
 from app.schemas.lesson import LessonResponse, LessonCreate
 from app.exceptions import NotFoundException
+from app.crud import authorized_required
 
 
 
@@ -25,8 +37,13 @@ async def remove(module_id: int, db: AsyncSession = Depends(get_db)):
 @router.get(
     "/{module_id}/lessons",
     response_model=list[LessonResponse],
+    dependencies=[Depends(authorized_required)]
 )
-async def read_lessons(module_id: int, db: AsyncSession = Depends(get_db)):
+async def read_lessons(module_id: int, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+    if user.role.code not in ["admin", "moderator"]:
+        module = await get_module(db, module_id)
+        if not module or not await user_enrolled(db, module.course_id, user.id):
+            raise HTTPException(status_code=403, detail="Нет доступа к модулю")
     lessons = await get_lessons_by_module(db, module_id)
     if not lessons:
         raise HTTPException(status_code=404, detail="Lessons not found")
@@ -35,3 +52,14 @@ async def read_lessons(module_id: int, db: AsyncSession = Depends(get_db)):
 @router.post("/{module_id}/lessons", response_model=LessonResponse, status_code=status.HTTP_201_CREATED)
 async def create_lesson_route(module_id: int, data: LessonCreate, db: AsyncSession = Depends(get_db)):
     return await create_lesson_for_module(db, module_id, data)
+
+
+@router.get("/{module_id}/progress", dependencies=[Depends(authorized_required)])
+async def module_progress(module_id: int, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+    module = await get_module(db, module_id)
+    if not module:
+        raise HTTPException(status_code=404, detail="Module not found")
+    if user.role.code not in ["admin", "moderator"] and not await user_enrolled(db, module.course_id, user.id):
+        raise HTTPException(status_code=403, detail="Нет доступа к модулю")
+    percent = await get_module_progress(db, module_id, user.id)
+    return {"percent": percent}

--- a/navuchai_api/app/schemas/lesson.py
+++ b/navuchai_api/app/schemas/lesson.py
@@ -1,23 +1,28 @@
 from typing import Optional, List
 from app.schemas.lesson_test import LessonTestBase
 from pydantic import BaseModel
+from .file import FileInDB
 
 class LessonBase(BaseModel):
     id: int
     module_id: int
     title: str
+    description: Optional[str] = None
     content: Optional[str] = None
     video: Optional[str] = None
     order: Optional[int] = None
+    files: List[FileInDB] = []
     class Config:
         from_attributes = True
 
 class LessonCreate(BaseModel):
     # module_id: int
     title: str
+    description: Optional[str] = None
     content: Optional[str] = None
     video: Optional[str] = None
     order: Optional[int] = None
+    file_ids: List[int] = []
 
 class LessonResponse(LessonBase):
     pass
@@ -32,6 +37,7 @@ from pydantic import BaseModel
 class LessonRead(BaseModel):
     id: int
     title: str
+    description: Optional[str] = None
     content: str
     video: Optional[str] = None
     order: int

--- a/navuchai_api/app/schemas/module.py
+++ b/navuchai_api/app/schemas/module.py
@@ -7,12 +7,14 @@ class ModuleBase(BaseModel):
     id: int
     course_id: int
     title: str
+    description: Optional[str] = None
     order: Optional[int] = None
     class Config:
         from_attributes = True
 
 class ModuleCreate(BaseModel):
     title: str
+    description: Optional[str] = None
 
 class ModuleWithLessons(ModuleBase):
     lessons: List['LessonBase'] = []
@@ -22,6 +24,7 @@ class ModuleWithLessons(ModuleBase):
 class ModuleRead(BaseModel):
     id: int
     title: str
+    description: Optional[str] = None
     order: int
     lessons: List[LessonRead]
 
@@ -31,6 +34,7 @@ class ModuleRead(BaseModel):
 
 class ModuleResponse(BaseModel):
     title: str
+    description: Optional[str] = None
     order: Optional[int] = None
 
     class Config:


### PR DESCRIPTION
## Summary
- allow descriptions for modules and lessons
- support attached files for lessons
- add lesson completion tracking and progress calculation
- restrict access to courses, modules and lessons
- expose endpoints to get course and module progress

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6853bf43842c8322a00c9c9a48815c57