### PR TITLE
Fix image field names in course and lesson schemas

### DIFF
--- a/navuchai_api/app/schemas/course.py
+++ b/navuchai_api/app/schemas/course.py
@@ -1,49 +1,62 @@
 from datetime import datetime
-from typing import Optional, List
-from pydantic import BaseModel
+from typing import List, Optional
+
 from app.schemas.module import ModuleBase
-from .module import ModuleRead
+from pydantic import BaseModel, Field
+
 from .file import FileInDB
+from .module import ModuleRead
+
 
 class CourseBase(BaseModel):
     id: int
     title: str
     description: Optional[str] = None
     author_id: int
-    img_id: Optional[int] = None
-    thumbnail_id: Optional[int] = None
+    img_id: Optional[int] = Field(default=None, alias="imgId")
+    thumbnail_id: Optional[int] = Field(default=None, alias="thumbnailId")
     image: Optional[FileInDB] = None
     thumbnail: Optional[FileInDB] = None
     created_at: datetime
+
     class Config:
         from_attributes = True
+        populate_by_name = True
+
 
 class CourseCreate(BaseModel):
     title: str
     description: Optional[str] = None
-    img_id: Optional[int] = None
-    thumbnail_id: Optional[int] = None
+    img_id: Optional[int] = Field(default=None, alias="imgId")
+    thumbnail_id: Optional[int] = Field(default=None, alias="thumbnailId")
+
+    class Config:
+        populate_by_name = True
+
 
 class CourseResponse(CourseBase):
     pass
 
+
 class CourseWithDetails(CourseBase):
-    modules: List['ModuleBase'] = []
+    modules: List["ModuleBase"] = []
+
     class Config:
         from_attributes = True
+        populate_by_name = True
+
 
 class CourseRead(BaseModel):
     id: int
     title: str
     description: str
-    img_id: Optional[int] = None
-    thumbnail_id: Optional[int] = None
+    img_id: Optional[int] = Field(default=None, alias="imgId")
+    thumbnail_id: Optional[int] = Field(default=None, alias="thumbnailId")
     image: Optional[FileInDB] = None
     thumbnail: Optional[FileInDB] = None
     modules: List[ModuleRead]
 
-    model_config = {
-        "from_attributes": True
-    }
+    model_config = {"from_attributes": True, "populate_by_name": True}
+
 
 CourseWithDetails.model_rebuild()

--- a/navuchai_api/app/schemas/lesson.py
+++ b/navuchai_api/app/schemas/lesson.py
@@ -1,7 +1,10 @@
-from typing import Optional, List
+from typing import List, Optional
+
 from app.schemas.lesson_test import LessonTestBase
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
 from .file import FileInDB
+
 
 class LessonBase(BaseModel):
     id: int
@@ -11,13 +14,16 @@ class LessonBase(BaseModel):
     content: Optional[str] = None
     video: Optional[str] = None
     order: Optional[int] = None
-    img_id: Optional[int] = None
-    thumbnail_id: Optional[int] = None
+    img_id: Optional[int] = Field(default=None, alias="imgId")
+    thumbnail_id: Optional[int] = Field(default=None, alias="thumbnailId")
     image: Optional[FileInDB] = None
     thumbnail: Optional[FileInDB] = None
     files: List[FileInDB] = []
+
     class Config:
         from_attributes = True
+        populate_by_name = True
+
 
 class LessonCreate(BaseModel):
     # module_id: int
@@ -26,19 +32,28 @@ class LessonCreate(BaseModel):
     content: Optional[str] = None
     video: Optional[str] = None
     order: Optional[int] = None
-    img_id: Optional[int] = None
-    thumbnail_id: Optional[int] = None
+    img_id: Optional[int] = Field(default=None, alias="imgId")
+    thumbnail_id: Optional[int] = Field(default=None, alias="thumbnailId")
     file_ids: List[int] = []
+
+    class Config:
+        populate_by_name = True
+
 
 class LessonResponse(LessonBase):
     pass
 
+
 class LessonWithTests(LessonBase):
-    tests: List['LessonTestBase'] = []
+    tests: List["LessonTestBase"] = []
+
     class Config:
         from_attributes = True
+        populate_by_name = True
+
 
 from pydantic import BaseModel
+
 
 class LessonRead(BaseModel):
     id: int
@@ -47,13 +62,12 @@ class LessonRead(BaseModel):
     content: str
     video: Optional[str] = None
     order: int
-    img_id: Optional[int] = None
-    thumbnail_id: Optional[int] = None
+    img_id: Optional[int] = Field(default=None, alias="imgId")
+    thumbnail_id: Optional[int] = Field(default=None, alias="thumbnailId")
     image: Optional[FileInDB] = None
     thumbnail: Optional[FileInDB] = None
 
-    model_config = {
-        "from_attributes": True
-    }
+    model_config = {"from_attributes": True, "populate_by_name": True}
+
 
 LessonWithTests.model_rebuild()


### PR DESCRIPTION
## Summary
- support `imgId` and `thumbnailId` JSON fields

## Testing
- `python -m py_compile navuchai_api/app/schemas/course.py navuchai_api/app/schemas/lesson.py`

------
https://chatgpt.com/codex/tasks/task_e_685a64c1f5bc83229f5d4da768f0aac7