### PR TITLE
Add course image auto update

### DIFF
--- a/navuchai_api/app/crud/__init__.py
+++ b/navuchai_api/app/crud/__init__.py
@@ -6,7 +6,15 @@ from .test import get_tests, get_test, create_test, delete_test, update_test, ge
 from .test_question import create_test_question, delete_test_question
 from .user import get_users, get_user, update_user, delete_user, update_user_role
 from .user_auth import get_current_user
-from .course import get_courses, get_course, create_course, update_course, delete_course, get_course_with_content
+from .course import (
+    get_courses,
+    get_course,
+    create_course,
+    update_course,
+    delete_course,
+    get_course_with_content,
+    update_course_images,
+)
 from .module import create_module, get_module, update_module, delete_module, get_modules_by_course, get_modules_with_lessons_by_course, create_module_for_course
 from .lesson import create_lesson, get_lesson, update_lesson, delete_lesson, get_lessons_by_module, create_lesson_for_module, complete_lesson, get_module_progress, get_course_progress
 from .enrollment import enroll_user, unenroll_user, get_user_courses, user_enrolled

--- a/navuchai_api/app/crud/course.py
+++ b/navuchai_api/app/crud/course.py
@@ -84,3 +84,12 @@ async def delete_course(db: AsyncSession, course_id: int):
     course = await get_course(db, course_id)
     await db.delete(course)
     await db.commit()
+
+async def update_course_images(db: AsyncSession, course_id: int, img_id: int, thumbnail_id: int) -> Course:
+    """Обновить изображения курса."""
+    course = await get_course(db, course_id)
+    course.img_id = img_id
+    course.thumbnail_id = thumbnail_id
+    await db.commit()
+    await db.refresh(course)
+    return course

--- a/navuchai_api/app/routes/files.py
+++ b/navuchai_api/app/routes/files.py
@@ -11,7 +11,7 @@ from io import BytesIO
 
 from app.dependencies import get_db
 from app.models import User
-from app.crud import admin_moderator_required
+from app.crud import admin_moderator_required, update_course_images
 from app.exceptions import DatabaseException
 from app.schemas.file import FileUploadResponse, FileCreate, FileUploadWithMobileResponse
 from app.crud import file as file_crud
@@ -91,6 +91,7 @@ async def upload_file(
 @router.post("/upload-image/", response_model=FileUploadWithMobileResponse)
 async def upload_image(
         file: UploadFile = File(...),
+        course_id: int | None = None,
         current_user: User = Depends(admin_moderator_required),
         db: AsyncSession = Depends(get_db)
 ):
@@ -159,6 +160,9 @@ async def upload_image(
             creator_id=current_user.id
         )
         db_mobile_file = await file_crud.create_file(db, mobile_file_data)
+
+        if course_id is not None:
+            await update_course_images(db, course_id, db_file.id, db_mobile_file.id)
 
         original_response = FileUploadResponse(
             id=db_file.id,


### PR DESCRIPTION
## Summary
- add a helper to update course images
- expose `update_course_images` via CRUD package
- allow passing `course_id` to file image upload and update the course

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685a8792db5483228c0ff4b26b7e7e3f