### PR TITLE
Implement lesson completion tracking and progress info

### DIFF
--- a/navuchai_api/app/routes/modules.py
+++ b/navuchai_api/app/routes/modules.py
@@ -49,7 +49,7 @@ async def read_lessons(
         db, module.course_id, user.id
     ):
         raise HTTPException(status_code=403, detail="Нет доступа к модулю")
-    lessons = await get_lessons_by_module(db, module_id)
+    lessons = await get_lessons_by_module(db, module_id, user.id)
     return lessons
 
 @router.post("/{module_id}/lessons", response_model=LessonResponse, status_code=status.HTTP_201_CREATED)

--- a/navuchai_api/app/schemas/lesson.py
+++ b/navuchai_api/app/schemas/lesson.py
@@ -19,6 +19,7 @@ class LessonBase(BaseModel):
     image: Optional[FileInDB] = None
     thumbnail: Optional[FileInDB] = None
     files: List[FileInDB] = []
+    completed: Optional[bool] = None
 
     class Config:
         from_attributes = True
@@ -66,6 +67,7 @@ class LessonRead(BaseModel):
     thumbnail_id: Optional[int] = Field(default=None, alias="thumbnailId")
     image: Optional[FileInDB] = None
     thumbnail: Optional[FileInDB] = None
+    completed: Optional[bool] = None
 
     model_config = {"from_attributes": True, "populate_by_name": True}
 


### PR DESCRIPTION
## Summary
- track lesson completion per user and expose via schemas
- mark lessons completed when listing module lessons and course details
- show module lessons with completion info when retrieving course modules

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685c07a00e3c8322bf16cabf47e04e44