### PR TITLE
Fix lesson access after course enrollment

### DIFF
--- a/navuchai_api/app/routes/lessons.py
+++ b/navuchai_api/app/routes/lessons.py
@@ -13,23 +13,46 @@ from app.crud import (
 from app.crud import authorized_required, get_current_user
 from app.schemas.lesson import LessonCreate, LessonResponse
 from app.models import User
-router = APIRouter(prefix="/api/lessons", tags=["Lessons"], dependencies=[Depends(admin_moderator_required)])
 
-@router.post("/", response_model=LessonResponse, status_code=status.HTTP_201_CREATED)
+router = APIRouter(prefix="/api/lessons", tags=["Lessons"])
+
+
+@router.post(
+    "/",
+    response_model=LessonResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(admin_moderator_required)],
+)
 async def create(data: LessonCreate, db: AsyncSession = Depends(get_db)):
     return await create_lesson(db, data)
 
-@router.put("/{lesson_id}", response_model=LessonResponse)
-async def update(lesson_id: int, data: LessonCreate, db: AsyncSession = Depends(get_db)):
+
+@router.put(
+    "/{lesson_id}",
+    response_model=LessonResponse,
+    dependencies=[Depends(admin_moderator_required)],
+)
+async def update(
+    lesson_id: int, data: LessonCreate, db: AsyncSession = Depends(get_db)
+):
     return await update_lesson(db, lesson_id, data)
 
-@router.delete("/{lesson_id}", status_code=status.HTTP_204_NO_CONTENT)
+
+@router.delete(
+    "/{lesson_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(admin_moderator_required)],
+)
 async def remove(lesson_id: int, db: AsyncSession = Depends(get_db)):
     await delete_lesson(db, lesson_id)
 
 
 @router.post("/{lesson_id}/complete", dependencies=[Depends(authorized_required)])
-async def mark_completed(lesson_id: int, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+async def mark_completed(
+    lesson_id: int,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
     lesson = await get_lesson(db, lesson_id)
     if not lesson:
         return

--- a/navuchai_api/app/routes/modules.py
+++ b/navuchai_api/app/routes/modules.py
@@ -12,7 +12,7 @@ from app.crud import (
     get_module_progress,
     user_enrolled,
     complete_lesson,
-    get_current_user
+    get_current_user,
 )
 from app.schemas.module import ModuleCreate, ModuleWithLessons
 from app.schemas.lesson import LessonResponse, LessonCreate
@@ -21,30 +21,48 @@ from app.crud import authorized_required
 from app.models import User
 
 
+router = APIRouter(prefix="/api/modules", tags=["Modules"])
 
-router = APIRouter(prefix="/api/modules", tags=["Modules"], dependencies=[Depends(admin_moderator_required)])
 
-@router.post("/", response_model=ModuleWithLessons, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/",
+    response_model=ModuleWithLessons,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(admin_moderator_required)],
+)
 async def create(data: ModuleCreate, db: AsyncSession = Depends(get_db)):
     return await create_module(db, data)
 
-@router.put("/{module_id}", response_model=ModuleWithLessons)
-async def update(module_id: int, data: ModuleCreate, db: AsyncSession = Depends(get_db)):
+
+@router.put(
+    "/{module_id}",
+    response_model=ModuleWithLessons,
+    dependencies=[Depends(admin_moderator_required)],
+)
+async def update(
+    module_id: int, data: ModuleCreate, db: AsyncSession = Depends(get_db)
+):
     return await update_module(db, module_id, data)
 
-@router.delete("/{module_id}", status_code=status.HTTP_204_NO_CONTENT)
+
+@router.delete(
+    "/{module_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(admin_moderator_required)],
+)
 async def remove(module_id: int, db: AsyncSession = Depends(get_db)):
     await delete_module(db, module_id)
+
 
 @router.get(
     "/{module_id}/lessons",
     response_model=list[LessonResponse],
-    dependencies=[Depends(authorized_required)]
+    dependencies=[Depends(authorized_required)],
 )
 async def read_lessons(
     module_id: int,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(get_current_user)
+    user: User = Depends(get_current_user),
 ):
     module = await get_module(db, module_id)
     if user.role.code not in ["admin", "moderator"] and not await user_enrolled(
@@ -54,17 +72,31 @@ async def read_lessons(
     lessons = await get_lessons_by_module(db, module_id, user.id)
     return lessons
 
-@router.post("/{module_id}/lessons", response_model=LessonResponse, status_code=status.HTTP_201_CREATED)
-async def create_lesson_route(module_id: int, data: LessonCreate, db: AsyncSession = Depends(get_db)):
+
+@router.post(
+    "/{module_id}/lessons",
+    response_model=LessonResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(admin_moderator_required)],
+)
+async def create_lesson_route(
+    module_id: int, data: LessonCreate, db: AsyncSession = Depends(get_db)
+):
     return await create_lesson_for_module(db, module_id, data)
 
 
 @router.get("/{module_id}/progress", dependencies=[Depends(authorized_required)])
-async def module_progress(module_id: int, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
+async def module_progress(
+    module_id: int,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
     module = await get_module(db, module_id)
     if not module:
         raise HTTPException(status_code=404, detail="Module not found")
-    if user.role.code not in ["admin", "moderator"] and not await user_enrolled(db, module.course_id, user.id):
+    if user.role.code not in ["admin", "moderator"] and not await user_enrolled(
+        db, module.course_id, user.id
+    ):
         raise HTTPException(status_code=403, detail="Нет доступа к модулю")
     percent = await get_module_progress(db, module_id, user.id)
     return {"percent": percent}


### PR DESCRIPTION
## Summary
- allow regular enrolled users to load modules and lessons
- keep admin/moderator check for creating or editing modules/lessons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686399db153c83228bad6437faf442e1