### PR TITLE
Fix async fetch of lesson module

### DIFF
--- a/navuchai_api/app/crud/lesson.py
+++ b/navuchai_api/app/crud/lesson.py
@@ -33,6 +33,7 @@ async def get_lesson(db: AsyncSession, lesson_id: int):
         .options(selectinload(Lesson.image))
         .options(selectinload(Lesson.thumbnail))
         .options(selectinload(Lesson.files))
+        .options(selectinload(Lesson.module))
         .where(Lesson.id == lesson_id)
     )
     lesson = result.scalar_one_or_none()


### PR DESCRIPTION
## Summary
- preload `Lesson.module` in `get_lesson`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6863b54425cc83228bb8013645414d59