### PR TITLE
Fix trailing slash behavior

### DIFF
--- a/navuchai_api/app/routes/courses.py
+++ b/navuchai_api/app/routes/courses.py
@@ -48,7 +48,7 @@ async def list_courses(
     return {"current": current, "courses": courses}
 
 @router.get(
-    "/{id}",
+    "/{id}/",
     response_model=CourseRead,
     response_model_exclude={"modules"},
 )
@@ -65,23 +65,23 @@ async def read_course(
     return course
 
 
-@router.post("", response_model=CourseResponse, status_code=status.HTTP_201_CREATED,
+@router.post("/", response_model=CourseResponse, status_code=status.HTTP_201_CREATED,
              dependencies=[Depends(admin_moderator_required)])
 async def create(course: CourseCreate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
     return await create_course(db, course, user.id)
 
 
-@router.put("/{course_id}", response_model=CourseResponse, dependencies=[Depends(admin_moderator_required)])
+@router.put("/{course_id}/", response_model=CourseResponse, dependencies=[Depends(admin_moderator_required)])
 async def update(course_id: int, data: CourseCreate, db: AsyncSession = Depends(get_db)):
     return await update_course(db, course_id, data)
 
 
-@router.delete("/{course_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(admin_moderator_required)])
+@router.delete("/{course_id}/", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(admin_moderator_required)])
 async def remove(course_id: int, db: AsyncSession = Depends(get_db)):
     await delete_course(db, course_id)
 
 
-@router.get("/{course_id}/modules", response_model=list[ModuleWithLessons], dependencies=[Depends(authorized_required)])
+@router.get("/{course_id}/modules/", response_model=list[ModuleWithLessons], dependencies=[Depends(authorized_required)])
 async def list_course_modules(course_id: int, db: AsyncSession = Depends(get_db),
                               user: User = Depends(get_current_user)):
     if user.role.code not in ["admin", "moderator"] and not await user_enrolled(db, course_id, user.id):
@@ -98,12 +98,12 @@ async def list_course_modules(course_id: int, db: AsyncSession = Depends(get_db)
     return []
 
 
-@router.post("/{course_id}/modules", response_model=ModuleResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/{course_id}/modules/", response_model=ModuleResponse, status_code=status.HTTP_201_CREATED)
 async def create_module_route(course_id: int, data: ModuleCreate, db: AsyncSession = Depends(get_db)):
     return await create_module_for_course(db, course_id, data)
 
 
-@router.get("/{course_id}/progress", dependencies=[Depends(authorized_required)])
+@router.get("/{course_id}/progress/", dependencies=[Depends(authorized_required)])
 async def course_progress(course_id: int, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
     if user.role.code not in ["admin", "moderator"] and not await user_enrolled(db, course_id, user.id):
         raise HTTPException(status_code=403, detail="Нет доступа к курсу")
@@ -111,13 +111,13 @@ async def course_progress(course_id: int, db: AsyncSession = Depends(get_db), us
     return {"percent": percent}
 
 
-@router.post("/{course_id}/tests", response_model=CourseTestBase, dependencies=[Depends(admin_moderator_required)])
+@router.post("/{course_id}/tests/", response_model=CourseTestBase, dependencies=[Depends(admin_moderator_required)])
 async def create_course_test_route(course_id: int, data: CourseTestCreate, db: AsyncSession = Depends(get_db)):
     data.course_id = course_id
     return await create_course_test(db, data)
 
 
-@router.get("/{course_id}/tests", response_model=list[TestResponse], dependencies=[Depends(authorized_required)])
+@router.get("/{course_id}/tests/", response_model=list[TestResponse], dependencies=[Depends(authorized_required)])
 async def list_course_tests_route(course_id: int, db: AsyncSession = Depends(get_db),
                                   user: User = Depends(get_current_user)):
     if user.role.code not in ["admin", "moderator"] and not await user_enrolled(db, course_id, user.id):

--- a/navuchai_api/app/routes/lessons.py
+++ b/navuchai_api/app/routes/lessons.py
@@ -18,7 +18,7 @@ router = APIRouter(prefix="/api/lessons", tags=["Lessons"])
 
 
 @router.post(
-    "",
+    "/",
     response_model=LessonResponse,
     status_code=status.HTTP_201_CREATED,
     dependencies=[Depends(admin_moderator_required)],
@@ -28,7 +28,7 @@ async def create(data: LessonCreate, db: AsyncSession = Depends(get_db)):
 
 
 @router.put(
-    "/{lesson_id}",
+    "/{lesson_id}/",
     response_model=LessonResponse,
     dependencies=[Depends(admin_moderator_required)],
 )
@@ -39,7 +39,7 @@ async def update(
 
 
 @router.delete(
-    "/{lesson_id}",
+    "/{lesson_id}/",
     status_code=status.HTTP_204_NO_CONTENT,
     dependencies=[Depends(admin_moderator_required)],
 )
@@ -48,7 +48,7 @@ async def remove(lesson_id: int, db: AsyncSession = Depends(get_db)):
 
 
 @router.get(
-    "/{lesson_id}",
+    "/{lesson_id}/",
     response_model=LessonResponse,
     dependencies=[Depends(authorized_required)],
 )
@@ -67,7 +67,7 @@ async def read(
     return lesson
 
 
-@router.post("/{lesson_id}/complete", dependencies=[Depends(authorized_required)])
+@router.post("/{lesson_id}/complete/", dependencies=[Depends(authorized_required)])
 async def mark_completed(
     lesson_id: int,
     db: AsyncSession = Depends(get_db),

--- a/navuchai_api/app/routes/modules.py
+++ b/navuchai_api/app/routes/modules.py
@@ -25,7 +25,7 @@ router = APIRouter(prefix="/api/modules", tags=["Modules"])
 
 
 @router.post(
-    "",
+    "/",
     response_model=ModuleWithLessons,
     status_code=status.HTTP_201_CREATED,
     dependencies=[Depends(admin_moderator_required)],
@@ -35,7 +35,7 @@ async def create(data: ModuleCreate, db: AsyncSession = Depends(get_db)):
 
 
 @router.put(
-    "/{module_id}",
+    "/{module_id}/",
     response_model=ModuleWithLessons,
     dependencies=[Depends(admin_moderator_required)],
 )
@@ -46,7 +46,7 @@ async def update(
 
 
 @router.delete(
-    "/{module_id}",
+    "/{module_id}/",
     status_code=status.HTTP_204_NO_CONTENT,
     dependencies=[Depends(admin_moderator_required)],
 )
@@ -56,7 +56,7 @@ async def remove(module_id: int, db: AsyncSession = Depends(get_db)):
 
 
 @router.get(
-    "/{module_id}/lessons",
+    "/{module_id}/lessons/",
     response_model=list[LessonResponse],
     dependencies=[Depends(authorized_required)],
 )
@@ -75,7 +75,7 @@ async def read_lessons(
 
 
 @router.post(
-    "/{module_id}/lessons",
+    "/{module_id}/lessons/",
     response_model=LessonResponse,
     status_code=status.HTTP_201_CREATED,
     dependencies=[Depends(admin_moderator_required)],
@@ -86,7 +86,7 @@ async def create_lesson_route(
     return await create_lesson_for_module(db, module_id, data)
 
 
-@router.get("/{module_id}/progress", dependencies=[Depends(authorized_required)])
+@router.get("/{module_id}/progress/", dependencies=[Depends(authorized_required)])
 async def module_progress(
     module_id: int,
     db: AsyncSession = Depends(get_db),


### PR DESCRIPTION
## Summary
- restore default redirect slashes behavior in FastAPI app
- keep trailing slash API endpoints for courses, modules, and lessons

## Testing
- `python -m py_compile navuchai_api/app/routes/courses.py navuchai_api/app/routes/modules.py navuchai_api/app/routes/lessons.py navuchai_api/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_686533de9af48322ba7952bf99dab6f3