### PR TITLE
Fix unenroll endpoint URL

### DIFF
--- a/navuchai_api/app/routes/enrollment.py
+++ b/navuchai_api/app/routes/enrollment.py
@@ -19,7 +19,7 @@ async def enroll_user_admin(course_id: int, user_id: int, db: AsyncSession = Dep
     await enroll_user(db, course_id, user_id)
 
 
-@router.delete("/{course_id}/unenroll/{user_id}/", status_code=status.HTTP_204_NO_CONTENT,
+@router.delete("/{course_id}/enroll/{user_id}/", status_code=status.HTTP_204_NO_CONTENT,
                dependencies=[Depends(admin_moderator_required)])
 async def unenroll(course_id: int, user_id: int, db: AsyncSession = Depends(get_db)):
     await unenroll_user(db, course_id, user_id)


### PR DESCRIPTION
## Summary
- fix enrollment router DELETE path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686549b6d78883228e42f890423a79fc