### PR TITLE
Add done field to courses

### DIFF
--- a/navuchai_api/app/crud/course.py
+++ b/navuchai_api/app/crud/course.py
@@ -52,6 +52,7 @@ async def get_courses(db: AsyncSession, user_id: int | None = None):
                 "thumbnail": c.thumbnail,
                 "enrolled": enrolled,
                 "progress": progress,
+                "done": progress == 100 if progress is not None else None,
             }
         )
     return courses

--- a/navuchai_api/app/routes/courses.py
+++ b/navuchai_api/app/routes/courses.py
@@ -43,7 +43,9 @@ async def list_courses(
         course_obj, _ = await get_last_course_and_lesson(db, user.id)
         if course_obj:
             setattr(course_obj, "enrolled", await user_enrolled(db, course_obj.id, user.id))
-            setattr(course_obj, "progress", await get_course_progress(db, course_obj.id, user.id))
+            progress = await get_course_progress(db, course_obj.id, user.id)
+            setattr(course_obj, "progress", progress)
+            setattr(course_obj, "done", progress == 100)
             current = CourseResponse.model_validate(course_obj)
     return {"current": current, "courses": courses}
 
@@ -61,7 +63,9 @@ async def read_course(
     if not course:
         raise HTTPException(status_code=404, detail="Курс не найден")
     setattr(course, "enrolled", await user_enrolled(db, id, user.id))
-    setattr(course, "progress", await get_course_progress(db, id, user.id))
+    progress = await get_course_progress(db, id, user.id)
+    setattr(course, "progress", progress)
+    setattr(course, "done", progress == 100)
     return course
 
 

--- a/navuchai_api/app/schemas/course.py
+++ b/navuchai_api/app/schemas/course.py
@@ -20,6 +20,7 @@ class CourseBase(BaseModel):
     created_at: datetime
     enrolled: Optional[bool] = None
     progress: Optional[float] = None
+    done: Optional[bool] = None
 
     class Config:
         from_attributes = True
@@ -59,6 +60,7 @@ class CourseRead(BaseModel):
     modules: List[ModuleRead]
     enrolled: Optional[bool] = None
     progress: Optional[float] = None
+    done: Optional[bool] = None
 
     model_config = {"from_attributes": True, "populate_by_name": True}
 


### PR DESCRIPTION
## Summary
- include a new `done` field in course schemas
- populate `done` in course listing and retrieval routes
- calculate `done` inside course CRUD logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for FastAPI and other packages)*

------
https://chatgpt.com/codex/tasks/task_e_686ba646786483228355e52c0f58ac3a