### PR TITLE
Add course test management endpoints

### DIFF
--- a/navuchai_api/app/crud/__init__.py
+++ b/navuchai_api/app/crud/__init__.py
@@ -23,5 +23,10 @@ from .result import get_analytics_user_performance
 from .analytics import get_analytics_data_by_view, get_column_mapping, get_sheet_name, get_filename
 from .lesson import create_lesson, get_lesson, update_lesson, delete_lesson, get_lessons_by_module, create_lesson_for_module, complete_lesson, get_module_progress, get_course_progress
 from .enrollment import enroll_user, unenroll_user, get_user_courses, user_enrolled
-from .course_test import create_course_test, get_course_tests
+from .course_test import (
+    create_course_test,
+    get_course_tests,
+    get_course_test,
+    delete_course_test,
+)
 from .module_test import create_module_test, get_module_tests

--- a/navuchai_api/app/crud/course_test.py
+++ b/navuchai_api/app/crud/course_test.py
@@ -19,3 +19,21 @@ async def get_course_tests(db: AsyncSession, course_id: int) -> list[CourseTest]
         select(CourseTest).where(CourseTest.course_id == course_id).options(selectinload(CourseTest.test))
     )
     return result.scalars().all()
+
+
+async def get_course_test(db: AsyncSession, course_id: int, test_id: int) -> CourseTest | None:
+    result = await db.execute(
+        select(CourseTest)
+        .where(CourseTest.course_id == course_id, CourseTest.test_id == test_id)
+        .options(selectinload(CourseTest.test))
+    )
+    return result.scalar_one_or_none()
+
+
+async def delete_course_test(db: AsyncSession, course_id: int, test_id: int) -> CourseTest | None:
+    course_test = await get_course_test(db, course_id, test_id)
+    if not course_test:
+        return None
+    await db.delete(course_test)
+    await db.commit()
+    return course_test

--- a/navuchai_api/app/routes/courses.py
+++ b/navuchai_api/app/routes/courses.py
@@ -17,6 +17,8 @@ from app.crud import (
     user_enrolled,
     create_course_test,
     get_course_tests,
+    get_course_test,
+    delete_course_test,
     get_current_user_optional,
     get_last_course_and_lesson,
 )
@@ -27,7 +29,7 @@ from app.schemas.test import TestResponse
 from app.schemas.module import ModuleWithLessons, ModuleCreate, ModuleResponse
 from app.exceptions import NotFoundException, DatabaseException
 from app.models import User
-from app.crud import authorized_required, get_course_with_content
+from app.crud import authorized_required
 
 router = APIRouter(prefix="/api/courses", tags=["Courses"])
 
@@ -124,3 +126,28 @@ async def list_course_tests_route(course_id: int, db: AsyncSession = Depends(get
         raise HTTPException(status_code=403, detail="Курс не завершен")
     tests = await get_course_tests(db, course_id)
     return [t.test for t in tests]
+
+
+@router.get("/{course_id}/tests/{test_id}/", response_model=TestResponse, dependencies=[Depends(authorized_required)])
+async def get_course_test_route(
+    course_id: int,
+    test_id: int,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    if user.role.code not in ["admin", "moderator"] and not await user_enrolled(db, course_id, user.id):
+        raise HTTPException(status_code=403, detail="Нет доступа к курсу")
+    progress = await get_course_progress(db, course_id, user.id)
+    if user.role.code not in ["admin", "moderator"] and progress < 100:
+        raise HTTPException(status_code=403, detail="Курс не завершен")
+    course_test = await get_course_test(db, course_id, test_id)
+    if not course_test:
+        raise HTTPException(status_code=404, detail="Тест не найден")
+    return course_test.test
+
+
+@router.delete("/{course_id}/tests/{test_id}/", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(admin_moderator_required)])
+async def delete_course_test_route(course_id: int, test_id: int, db: AsyncSession = Depends(get_db)):
+    course_test = await delete_course_test(db, course_id, test_id)
+    if not course_test:
+        raise HTTPException(status_code=404, detail="Тест не найден")


### PR DESCRIPTION
## Summary
- manage course tests CRUD
- expose course test CRUD in service layer
- restrict access to course tests by completion status

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686bb138bd948322869331de078ff102