### PR TITLE
Add enrollment info for courses

### DIFF
--- a/navuchai_api/app/crud/__init__.py
+++ b/navuchai_api/app/crud/__init__.py
@@ -1,8 +1,29 @@
-from .permissions import role_required, admin_required, moderator_required, user_required, admin_moderator_required, \
-    authorized_required
-from .question import get_questions, get_question, create_question, update_question, delete_question, \
-    get_questions_by_test_id
-from .test import get_tests, get_test, create_test, delete_test, update_test, get_user_tests, get_test_by_code, get_test_by_access_code
+from .permissions import (
+    role_required,
+    admin_required,
+    moderator_required,
+    user_required,
+    admin_moderator_required,
+    authorized_required,
+)
+from .question import (
+    get_questions,
+    get_question,
+    create_question,
+    update_question,
+    delete_question,
+    get_questions_by_test_id,
+)
+from .test import (
+    get_tests,
+    get_test,
+    create_test,
+    delete_test,
+    update_test,
+    get_user_tests,
+    get_test_by_code,
+    get_test_by_access_code,
+)
 from .test_question import create_test_question, delete_test_question
 from .user import get_users, get_user, update_user, delete_user, update_user_role
 from .user_auth import get_current_user, get_current_user_optional
@@ -16,13 +37,41 @@ from .course import (
     update_course_images,
     get_last_course_and_lesson,
 )
-from .module import create_module, get_module, update_module, delete_module, get_modules_by_course, get_modules_with_lessons_by_course, create_module_for_course
-from .lesson import create_lesson, get_lesson, update_lesson, delete_lesson, get_lessons_by_module, create_lesson_for_module
-from .enrollment import enroll_user, unenroll_user, get_user_courses
+from .module import (
+    create_module,
+    get_module,
+    update_module,
+    delete_module,
+    get_modules_by_course,
+    get_modules_with_lessons_by_course,
+    create_module_for_course,
+)
+from .lesson import (
+    create_lesson,
+    get_lesson,
+    update_lesson,
+    delete_lesson,
+    get_lessons_by_module,
+    create_lesson_for_module,
+    complete_lesson,
+    get_module_progress,
+    get_course_progress,
+)
+from .enrollment import (
+    enroll_user,
+    unenroll_user,
+    get_user_courses,
+    user_enrolled,
+    count_course_enrollments,
+    get_course_enrollment,
+)
 from .result import get_analytics_user_performance
-from .analytics import get_analytics_data_by_view, get_column_mapping, get_sheet_name, get_filename
-from .lesson import create_lesson, get_lesson, update_lesson, delete_lesson, get_lessons_by_module, create_lesson_for_module, complete_lesson, get_module_progress, get_course_progress
-from .enrollment import enroll_user, unenroll_user, get_user_courses, user_enrolled
+from .analytics import (
+    get_analytics_data_by_view,
+    get_column_mapping,
+    get_sheet_name,
+    get_filename,
+)
 from .course_test import (
     create_course_test,
     get_course_tests,

--- a/navuchai_api/app/crud/enrollment.py
+++ b/navuchai_api/app/crud/enrollment.py
@@ -1,6 +1,6 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
-from sqlalchemy import and_
+from sqlalchemy import and_, func
 from app.models import CourseEnrollment
 from app.exceptions import NotFoundException
 
@@ -34,3 +34,19 @@ async def user_enrolled(db: AsyncSession, course_id: int, user_id: int) -> bool:
         )
     )
     return result.scalar_one_or_none() is not None
+
+
+async def count_course_enrollments(db: AsyncSession, course_id: int) -> int:
+    result = await db.execute(
+        select(func.count()).select_from(CourseEnrollment).where(CourseEnrollment.course_id == course_id)
+    )
+    return result.scalar() or 0
+
+
+async def get_course_enrollment(db: AsyncSession, course_id: int, user_id: int) -> CourseEnrollment | None:
+    result = await db.execute(
+        select(CourseEnrollment).where(
+            and_(CourseEnrollment.course_id == course_id, CourseEnrollment.user_id == user_id)
+        )
+    )
+    return result.scalar_one_or_none()

--- a/navuchai_api/app/schemas/course.py
+++ b/navuchai_api/app/schemas/course.py
@@ -18,6 +18,9 @@ class CourseBase(BaseModel):
     image: Optional[FileInDB] = None
     thumbnail: Optional[FileInDB] = None
     created_at: datetime
+    enrolled: Optional[bool] = None
+    enrolled_count: int = Field(default=0, alias="enrolledCount")
+    enrolled_days: Optional[int] = Field(default=None, alias="enrolledDays")
 
     class Config:
         from_attributes = True
@@ -55,6 +58,9 @@ class CourseRead(BaseModel):
     image: Optional[FileInDB] = None
     thumbnail: Optional[FileInDB] = None
     modules: List[ModuleRead]
+    enrolled: Optional[bool] = None
+    enrolled_count: int = Field(default=0, alias="enrolledCount")
+    enrolled_days: Optional[int] = Field(default=None, alias="enrolledDays")
 
     model_config = {"from_attributes": True, "populate_by_name": True}
 


### PR DESCRIPTION
## Summary
- extend course schemas with enrollment data
- expose enrollment helper functions in crud
- include enrollment count/duration in course routes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686f6facb74c83229cb3192a1000947d