### PR TITLE
Fix course retrieval endpoint and expose lesson count

### DIFF
--- a/navuchai_api/app/routes/courses.py
+++ b/navuchai_api/app/routes/courses.py
@@ -49,24 +49,24 @@ async def list_courses(
         course_obj, lesson_obj = await get_last_course_and_lesson(db, user.id)
         if course_obj:
             current = {
-                "course": CourseResponse.model_validate(course_obj),
-                "lesson": LessonResponse.model_validate(lesson_obj),
+                "course": CourseResponse.model_validate(course_obj).model_dump(),
+                "lesson": LessonResponse.model_validate(lesson_obj).model_dump(),
             }
     return {"current": current, "courses": courses}
 
 
 @router.get(
-    "/{id}",
+    "/{course_id}/",
     response_model=CourseRead,
     response_model_exclude={"modules"},
     dependencies=[Depends(authorized_required)],
 )
 async def read_course(
-    id: int,
+    course_id: int,
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
-    course = await get_course_with_content(db, id, user)
+    course = await get_course_with_content(db, course_id, user)
     if not course:
         raise HTTPException(status_code=404, detail="Курс не найден")
     return course

--- a/navuchai_api/app/schemas/course.py
+++ b/navuchai_api/app/schemas/course.py
@@ -21,6 +21,7 @@ class CourseBase(BaseModel):
     enrolled: Optional[bool] = None
     students_count: int = Field(default=0, alias="studentsCount")
     enrolled_days: Optional[int] = Field(default=None, alias="enrolledDays")
+    done: Optional[bool] = None
 
     class Config:
         from_attributes = True
@@ -61,6 +62,8 @@ class CourseRead(BaseModel):
     enrolled: Optional[bool] = None
     students_count: int = Field(default=0, alias="studentsCount")
     enrolled_days: Optional[int] = Field(default=None, alias="enrolledDays")
+    done: Optional[bool] = None
+    lessons_count: Optional[int] = Field(default=None, alias="lessonsCount")
 
     model_config = {"from_attributes": True, "populate_by_name": True}
 


### PR DESCRIPTION
## Summary
- allow trailing slash when retrieving a single course
- include completion status and lesson count in course details

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686f7b90eb648322a9d47e519ebcfdfe