### PR TITLE
Add FAQ system

### DIFF
--- a/navuchai_api/app/crud/__init__.py
+++ b/navuchai_api/app/crud/__init__.py
@@ -33,3 +33,17 @@ from .course_test import (
 )
 from .module_test import create_module_test, get_module_tests
 from .course_rating import set_course_rating, get_course_avg_rating
+from .faq_category import (
+    create_faq_category,
+    get_faq_category,
+    get_faq_categories,
+    update_faq_category,
+    delete_faq_category,
+)
+from .faq import (
+    create_faq,
+    get_faq,
+    get_faqs,
+    answer_faq,
+    increment_faq_hits,
+)

--- a/navuchai_api/app/crud/faq.py
+++ b/navuchai_api/app/crud/faq.py
@@ -1,0 +1,64 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy import update as sql_update
+
+from app.models import Faq
+from app.schemas.faq import FaqCreate, FaqAnswerUpdate
+from app.exceptions import DatabaseException, NotFoundException
+
+
+async def create_faq(db: AsyncSession, data: FaqCreate, owner_id: int, username: str) -> Faq:
+    try:
+        obj = Faq(category_id=data.category_id, question=data.question, owner_id=owner_id, username=username)
+        db.add(obj)
+        await db.commit()
+        await db.refresh(obj)
+        return obj
+    except SQLAlchemyError as e:
+        await db.rollback()
+        raise DatabaseException(f"Ошибка при создании вопроса FAQ: {str(e)}")
+
+
+async def get_faq(db: AsyncSession, faq_id: int) -> Faq:
+    try:
+        res = await db.execute(select(Faq).where(Faq.id == faq_id))
+        obj = res.scalar_one_or_none()
+        if not obj:
+            raise NotFoundException("Вопрос FAQ не найден")
+        return obj
+    except SQLAlchemyError as e:
+        raise DatabaseException(f"Ошибка при получении вопроса FAQ: {str(e)}")
+
+
+async def get_faqs(db: AsyncSession, category_id: int | None = None) -> list[Faq]:
+    try:
+        stmt = select(Faq)
+        if category_id is not None:
+            stmt = stmt.where(Faq.category_id == category_id)
+        result = await db.execute(stmt)
+        return result.scalars().all()
+    except SQLAlchemyError as e:
+        raise DatabaseException(f"Ошибка при получении вопросов FAQ: {str(e)}")
+
+
+async def answer_faq(db: AsyncSession, faq_id: int, data: FaqAnswerUpdate) -> Faq:
+    obj = await get_faq(db, faq_id)
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(obj, field, value)
+    try:
+        await db.commit()
+        await db.refresh(obj)
+        return obj
+    except SQLAlchemyError as e:
+        await db.rollback()
+        raise DatabaseException(f"Ошибка при обновлении вопроса FAQ: {str(e)}")
+
+
+async def increment_faq_hits(db: AsyncSession, faq_id: int) -> None:
+    try:
+        await db.execute(sql_update(Faq).where(Faq.id == faq_id).values(hits=Faq.hits + 1))
+        await db.commit()
+    except SQLAlchemyError:
+        await db.rollback()
+

--- a/navuchai_api/app/crud/faq_category.py
+++ b/navuchai_api/app/crud/faq_category.py
@@ -1,0 +1,61 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.models import FaqCategory
+from app.schemas.faq_category import FaqCategoryCreate, FaqCategoryUpdate
+from app.exceptions import DatabaseException, NotFoundException
+
+
+async def create_faq_category(db: AsyncSession, data: FaqCategoryCreate) -> FaqCategory:
+    try:
+        obj = FaqCategory(**data.model_dump())
+        db.add(obj)
+        await db.commit()
+        await db.refresh(obj)
+        return obj
+    except SQLAlchemyError as e:
+        await db.rollback()
+        raise DatabaseException(f"Ошибка при создании категории FAQ: {str(e)}")
+
+
+async def get_faq_category(db: AsyncSession, category_id: int) -> FaqCategory:
+    try:
+        result = await db.execute(select(FaqCategory).where(FaqCategory.id == category_id))
+        obj = result.scalar_one_or_none()
+        if not obj:
+            raise NotFoundException("Категория FAQ не найдена")
+        return obj
+    except SQLAlchemyError as e:
+        raise DatabaseException(f"Ошибка при получении категории FAQ: {str(e)}")
+
+
+async def get_faq_categories(db: AsyncSession) -> list[FaqCategory]:
+    try:
+        result = await db.execute(select(FaqCategory))
+        return result.scalars().all()
+    except SQLAlchemyError as e:
+        raise DatabaseException(f"Ошибка при получении категорий FAQ: {str(e)}")
+
+
+async def update_faq_category(db: AsyncSession, category_id: int, data: FaqCategoryUpdate) -> FaqCategory:
+    try:
+        obj = await get_faq_category(db, category_id)
+        for field, value in data.model_dump(exclude_unset=True).items():
+            setattr(obj, field, value)
+        await db.commit()
+        await db.refresh(obj)
+        return obj
+    except SQLAlchemyError as e:
+        await db.rollback()
+        raise DatabaseException(f"Ошибка при обновлении категории FAQ: {str(e)}")
+
+
+async def delete_faq_category(db: AsyncSession, category_id: int) -> None:
+    try:
+        obj = await get_faq_category(db, category_id)
+        await db.delete(obj)
+        await db.commit()
+    except SQLAlchemyError as e:
+        await db.rollback()
+        raise DatabaseException(f"Ошибка при удалении категории FAQ: {str(e)}")

--- a/navuchai_api/app/main.py
+++ b/navuchai_api/app/main.py
@@ -7,7 +7,7 @@ from app.routes import (
     category, locale, files, role, user_groups,
     test_access, test_status, results, question_type,
     test_access_status, courses, modules, lessons, enrollment, module_tests,
-    test_import, analytics_views
+    test_import, analytics_views, faq, faq_categories
 )
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -44,6 +44,8 @@ app.include_router(question_type)
 app.include_router(test_access_status)
 app.include_router(test_import)
 app.include_router(analytics_views)
+app.include_router(faq)
+app.include_router(faq_categories)
 
 
 @app.on_event("startup")

--- a/navuchai_api/app/models/__init__.py
+++ b/navuchai_api/app/models/__init__.py
@@ -27,6 +27,8 @@ from .organization import Organization
 from .position import Position
 from .department import Department
 from .course_rating import CourseRating
+from .faq_category import FaqCategory
+from .faq import Faq
 
 __all__ = [
     "Base",
@@ -56,6 +58,8 @@ __all__ = [
     "Organization",
     "Position",
     "Department",
-    "CourseRating"
+    "CourseRating",
+    "FaqCategory",
+    "Faq"
 ]
 

--- a/navuchai_api/app/models/faq.py
+++ b/navuchai_api/app/models/faq.py
@@ -1,0 +1,20 @@
+from sqlalchemy import Column, Integer, Text, Boolean, ForeignKey, TIMESTAMP
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+from app.models.base import Base
+
+class Faq(Base):
+    __tablename__ = 'faq'
+
+    id = Column(Integer, primary_key=True, index=True)
+    category_id = Column(Integer, ForeignKey('faq_categories.id'), nullable=False)
+    username = Column(Text)
+    question = Column(Text)
+    date = Column(TIMESTAMP, nullable=False, server_default=func.now())
+    answer = Column(Text)
+    hits = Column(Integer, nullable=False, default=0)
+    active = Column(Boolean, nullable=False, default=True)
+    owner_id = Column(Integer, ForeignKey('user.id'), nullable=False)
+
+    category = relationship('FaqCategory', back_populates='faqs')
+    owner = relationship('User')

--- a/navuchai_api/app/models/faq_category.py
+++ b/navuchai_api/app/models/faq_category.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, Text, Boolean, ForeignKey
+from sqlalchemy.orm import relationship
+from app.models.base import Base
+
+class FaqCategory(Base):
+    __tablename__ = 'faq_categories'
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(Text, nullable=False)
+    user_group_id = Column(Integer, ForeignKey('user_group.id'), nullable=True)
+    express = Column(Boolean, nullable=True, default=False)
+
+    faqs = relationship('Faq', back_populates='category')
+    user_group = relationship('UserGroup')

--- a/navuchai_api/app/routes/__init__.py
+++ b/navuchai_api/app/routes/__init__.py
@@ -20,6 +20,8 @@ from app.routes.enrollment import router as enrollment_router
 from app.routes.module_tests import router as module_tests_router
 from app.routes.test_import import router as test_import_router
 from .analytics import router as analytics_views_router
+from app.routes.faq import router as faq_router
+from app.routes.faq_categories import router as faq_categories_router
 
 auth = auth_router
 tests = tests_router
@@ -43,3 +45,5 @@ enrollment = enrollment_router
 module_tests = module_tests_router
 test_import = test_import_router
 analytics_views = analytics_views_router
+faq = faq_router
+faq_categories = faq_categories_router

--- a/navuchai_api/app/routes/faq.py
+++ b/navuchai_api/app/routes/faq.py
@@ -1,0 +1,71 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.crud import (
+    create_faq,
+    get_faq,
+    get_faqs,
+    answer_faq,
+    increment_faq_hits,
+    admin_moderator_required,
+    authorized_required,
+    get_current_user,
+)
+from app.dependencies import get_db
+from app.schemas import FaqCreate, FaqAnswerUpdate, FaqInDB
+from app.exceptions import DatabaseException
+from app.models import User
+
+router = APIRouter(prefix="/api/faq", tags=["FAQ"])
+
+
+@router.post("/", response_model=FaqInDB)
+async def create_faq_route(
+    data: FaqCreate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    try:
+        return await create_faq(db, data, user.id, user.name)
+    except SQLAlchemyError:
+        raise DatabaseException("Ошибка при создании вопроса FAQ")
+
+
+@router.get("/", response_model=list[FaqInDB])
+async def list_faq_route(
+    category_id: int | None = None,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(authorized_required),
+):
+    try:
+        return await get_faqs(db, category_id)
+    except SQLAlchemyError:
+        raise DatabaseException("Ошибка при получении вопросов FAQ")
+
+
+@router.get("/{faq_id}/", response_model=FaqInDB)
+async def get_faq_route(
+    faq_id: int,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(authorized_required),
+):
+    try:
+        await increment_faq_hits(db, faq_id)
+        return await get_faq(db, faq_id)
+    except SQLAlchemyError:
+        raise DatabaseException("Ошибка при получении вопроса FAQ")
+
+
+@router.put("/{faq_id}/answer/", response_model=FaqInDB)
+async def answer_faq_route(
+    faq_id: int,
+    data: FaqAnswerUpdate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(admin_moderator_required),
+):
+    try:
+        return await answer_faq(db, faq_id, data)
+    except SQLAlchemyError:
+        raise DatabaseException("Ошибка при обновлении вопроса FAQ")
+

--- a/navuchai_api/app/routes/faq_categories.py
+++ b/navuchai_api/app/routes/faq_categories.py
@@ -1,0 +1,84 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.crud import (
+    create_faq_category,
+    get_faq_category,
+    get_faq_categories,
+    update_faq_category,
+    delete_faq_category,
+    admin_moderator_required,
+    authorized_required,
+)
+from app.dependencies import get_db
+from app.schemas import (
+    FaqCategoryCreate,
+    FaqCategoryUpdate,
+    FaqCategoryInDB,
+)
+from app.exceptions import DatabaseException
+from app.models import User
+
+router = APIRouter(prefix="/api/faq-categories", tags=["FAQ Categories"])
+
+
+@router.post("/", response_model=FaqCategoryInDB)
+async def create_category_route(
+    data: FaqCategoryCreate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(admin_moderator_required),
+):
+    try:
+        return await create_faq_category(db, data)
+    except SQLAlchemyError:
+        raise DatabaseException("Ошибка при создании категории FAQ")
+
+
+@router.get("/", response_model=list[FaqCategoryInDB])
+async def list_categories_route(
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(authorized_required),
+):
+    try:
+        return await get_faq_categories(db)
+    except SQLAlchemyError:
+        raise DatabaseException("Ошибка при получении категорий FAQ")
+
+
+@router.get("/{category_id}/", response_model=FaqCategoryInDB)
+async def get_category_route(
+    category_id: int,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(authorized_required),
+):
+    try:
+        return await get_faq_category(db, category_id)
+    except SQLAlchemyError:
+        raise DatabaseException("Ошибка при получении категории FAQ")
+
+
+@router.put("/{category_id}/", response_model=FaqCategoryInDB)
+async def update_category_route(
+    category_id: int,
+    data: FaqCategoryUpdate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(admin_moderator_required),
+):
+    try:
+        return await update_faq_category(db, category_id, data)
+    except SQLAlchemyError:
+        raise DatabaseException("Ошибка при обновлении категории FAQ")
+
+
+@router.delete("/{category_id}/")
+async def delete_category_route(
+    category_id: int,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(admin_moderator_required),
+):
+    try:
+        await delete_faq_category(db, category_id)
+        return {"detail": "Категория FAQ удалена"}
+    except SQLAlchemyError:
+        raise DatabaseException("Ошибка при удалении категории FAQ")

--- a/navuchai_api/app/schemas/__init__.py
+++ b/navuchai_api/app/schemas/__init__.py
@@ -6,3 +6,5 @@ from .user_auth import Token, UserLogin, UserOut
 from .role import RoleBase
 from .course_test import CourseTestBase, CourseTestCreate
 from .module_test import ModuleTestBase, ModuleTestCreate
+from .faq import FaqCreate, FaqAnswerUpdate, FaqInDB
+from .faq_category import FaqCategoryCreate, FaqCategoryUpdate, FaqCategoryInDB

--- a/navuchai_api/app/schemas/faq.py
+++ b/navuchai_api/app/schemas/faq.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class FaqBase(BaseModel):
+    id: int
+    category_id: int
+    username: str | None = None
+    question: str | None = None
+    date: datetime
+    answer: str | None = None
+    hits: int
+    active: bool
+    owner_id: int
+
+    class Config:
+        from_attributes = True
+
+
+class FaqCreate(BaseModel):
+    category_id: int
+    question: str
+
+
+class FaqAnswerUpdate(BaseModel):
+    answer: str
+    active: bool | None = True
+
+
+class FaqInDB(FaqBase):
+    pass

--- a/navuchai_api/app/schemas/faq_category.py
+++ b/navuchai_api/app/schemas/faq_category.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class FaqCategoryBase(BaseModel):
+    title: str
+    user_group_id: int | None = None
+    express: bool | None = False
+
+
+class FaqCategoryCreate(FaqCategoryBase):
+    pass
+
+
+class FaqCategoryUpdate(BaseModel):
+    title: str | None = None
+    user_group_id: int | None = None
+    express: bool | None = None
+
+
+class FaqCategoryInDB(FaqCategoryBase):
+    id: int
+    class Config:
+        from_attributes = True


### PR DESCRIPTION
## Summary
- implement `Faq` and `FaqCategory` models
- add CRUD logic and routes for FAQ questions and categories
- register new routers in application

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6881ce47cb5083228631dab292798b55