### PR TITLE
Implement FAQ access control and answered flag

### DIFF
--- a/navuchai_api/app/crud/__init__.py
+++ b/navuchai_api/app/crud/__init__.py
@@ -47,3 +47,13 @@ from .faq import (
     answer_faq,
     increment_faq_hits,
 )
+from .user_group import (
+    create_group,
+    get_group,
+    get_groups,
+    update_group,
+    delete_group,
+    add_group_member,
+    remove_group_member,
+    is_user_in_group,
+)

--- a/navuchai_api/app/crud/faq.py
+++ b/navuchai_api/app/crud/faq.py
@@ -10,7 +10,13 @@ from app.exceptions import DatabaseException, NotFoundException
 
 async def create_faq(db: AsyncSession, data: FaqCreate, owner_id: int, username: str) -> Faq:
     try:
-        obj = Faq(category_id=data.category_id, question=data.question, owner_id=owner_id, username=username)
+        obj = Faq(
+            category_id=data.category_id,
+            question=data.question,
+            owner_id=owner_id,
+            username=username,
+            answered=False,
+        )
         db.add(obj)
         await db.commit()
         await db.refresh(obj)
@@ -46,6 +52,8 @@ async def answer_faq(db: AsyncSession, faq_id: int, data: FaqAnswerUpdate) -> Fa
     obj = await get_faq(db, faq_id)
     for field, value in data.model_dump(exclude_unset=True).items():
         setattr(obj, field, value)
+    if data.answer is not None:
+        obj.answered = True
     try:
         await db.commit()
         await db.refresh(obj)

--- a/navuchai_api/app/crud/user_group.py
+++ b/navuchai_api/app/crud/user_group.py
@@ -118,4 +118,14 @@ async def remove_group_member(db: AsyncSession, group_id: int, user_id: int) -> 
         return member
     except SQLAlchemyError as e:
         await db.rollback()
-        raise DatabaseException(f"Ошибка при удалении пользователя из группы: {str(e)}") 
+        raise DatabaseException(f"Ошибка при удалении пользователя из группы: {str(e)}")
+
+
+async def is_user_in_group(db: AsyncSession, group_id: int, user_id: int) -> bool:
+    result = await db.execute(
+        select(UserGroupMember).where(
+            UserGroupMember.group_id == group_id,
+            UserGroupMember.user_id == user_id,
+        )
+    )
+    return result.scalar_one_or_none() is not None

--- a/navuchai_api/app/models/faq.py
+++ b/navuchai_api/app/models/faq.py
@@ -12,6 +12,7 @@ class Faq(Base):
     question = Column(Text)
     date = Column(TIMESTAMP, nullable=False, server_default=func.now())
     answer = Column(Text)
+    answered = Column(Boolean, nullable=False, default=False)
     hits = Column(Integer, nullable=False, default=0)
     active = Column(Boolean, nullable=False, default=True)
     owner_id = Column(Integer, ForeignKey('user.id'), nullable=False)

--- a/navuchai_api/app/routes/faq.py
+++ b/navuchai_api/app/routes/faq.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -11,6 +11,8 @@ from app.crud import (
     admin_moderator_required,
     authorized_required,
     get_current_user,
+    get_faq_category,
+    is_user_in_group,
 )
 from app.dependencies import get_db
 from app.schemas import FaqCreate, FaqAnswerUpdate, FaqInDB
@@ -27,6 +29,13 @@ async def create_faq_route(
     user: User = Depends(get_current_user),
 ):
     try:
+        category = await get_faq_category(db, data.category_id)
+        if (
+            category.user_group_id is not None
+            and user.role.code not in ["admin", "moderator"]
+            and not await is_user_in_group(db, category.user_group_id, user.id)
+        ):
+            raise HTTPException(status_code=403, detail="Нет доступа к категории")
         return await create_faq(db, data, user.id, user.name)
     except SQLAlchemyError:
         raise DatabaseException("Ошибка при создании вопроса FAQ")
@@ -39,7 +48,23 @@ async def list_faq_route(
     user: User = Depends(authorized_required),
 ):
     try:
-        return await get_faqs(db, category_id)
+        if category_id is not None:
+            category = await get_faq_category(db, category_id)
+            if (
+                category.user_group_id is not None
+                and user.role.code not in ["admin", "moderator"]
+                and not await is_user_in_group(db, category.user_group_id, user.id)
+            ):
+                raise HTTPException(status_code=403, detail="Нет доступа к категории")
+        faqs = await get_faqs(db, category_id)
+        if user.role.code not in ["admin", "moderator"]:
+            filtered = []
+            for f in faqs:
+                cat = await get_faq_category(db, f.category_id)
+                if cat.user_group_id is None or await is_user_in_group(db, cat.user_group_id, user.id):
+                    filtered.append(f)
+            faqs = filtered
+        return faqs
     except SQLAlchemyError:
         raise DatabaseException("Ошибка при получении вопросов FAQ")
 
@@ -51,8 +76,16 @@ async def get_faq_route(
     user: User = Depends(authorized_required),
 ):
     try:
+        faq = await get_faq(db, faq_id)
+        category = await get_faq_category(db, faq.category_id)
+        if (
+            category.user_group_id is not None
+            and user.role.code not in ["admin", "moderator"]
+            and not await is_user_in_group(db, category.user_group_id, user.id)
+        ):
+            raise HTTPException(status_code=403, detail="Нет доступа к вопросу")
         await increment_faq_hits(db, faq_id)
-        return await get_faq(db, faq_id)
+        return faq
     except SQLAlchemyError:
         raise DatabaseException("Ошибка при получении вопроса FAQ")
 

--- a/navuchai_api/app/schemas/faq.py
+++ b/navuchai_api/app/schemas/faq.py
@@ -9,6 +9,7 @@ class FaqBase(BaseModel):
     question: str | None = None
     date: datetime
     answer: str | None = None
+    answered: bool
     hits: int
     active: bool
     owner_id: int


### PR DESCRIPTION
## Summary
- restrict FAQ category and question visibility to group members similar to course access
- mark FAQ entries with a new `answered` flag when an answer is provided
- expose helper to check user membership in a group

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688229b7134c8322a4fb42fdb265da96