### PR TITLE
Exclude lesson content in modules endpoint

### DIFF
--- a/navuchai_api/app/routes/courses.py
+++ b/navuchai_api/app/routes/courses.py
@@ -174,6 +174,8 @@ async def list_course_modules(course_id: int, db: AsyncSession = Depends(get_db)
     modules = await get_modules_by_course(db, course_id)
     for module in modules:
         module.lessons = await get_lessons_by_module(db, module.id, user.id)
+        for lesson in module.lessons:
+            lesson.content = None
     if modules:
         return modules
     try:


### PR DESCRIPTION
## Summary
- stop returning lesson content in course modules response to reduce payload

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_689b001c868083229c21b5feac480a9b