### PR TITLE
feat: support multiple user group access for FAQ

### DIFF
--- a/faq_migration.sql
+++ b/faq_migration.sql
@@ -7,3 +7,12 @@ ALTER TABLE faq
     DROP CONSTRAINT IF EXISTS faq_category_id_fkey,
     ADD CONSTRAINT faq_category_id_fkey FOREIGN KEY (category_id)
         REFERENCES faq_categories (id) ON DELETE CASCADE;
+
+ALTER TABLE faq_categories
+    DROP COLUMN IF EXISTS user_group_id;
+
+CREATE TABLE faq_category_access (
+    id SERIAL PRIMARY KEY,
+    faq_category_id INTEGER NOT NULL REFERENCES faq_categories (id) ON DELETE CASCADE,
+    user_group_id INTEGER NOT NULL REFERENCES user_group (id) ON DELETE CASCADE
+);

--- a/navuchai_api/app/models/__init__.py
+++ b/navuchai_api/app/models/__init__.py
@@ -31,6 +31,7 @@ from .test_group import TestGroup
 from .test_group_test import TestGroupTest
 from .test_group_access import TestGroupAccess
 from .faq_category import FaqCategory
+from .faq_category_access import FaqCategoryAccess
 from .faq import Faq
 
 __all__ = [
@@ -66,6 +67,7 @@ __all__ = [
     "TestGroupTest",
     "TestGroupAccess",
     "FaqCategory",
+    "FaqCategoryAccess",
     "Faq"
 ]
 

--- a/navuchai_api/app/models/faq_category.py
+++ b/navuchai_api/app/models/faq_category.py
@@ -1,14 +1,18 @@
-from sqlalchemy import Column, Integer, Text, Boolean, ForeignKey
+from sqlalchemy import Column, Integer, Text, Boolean
 from sqlalchemy.orm import relationship
 from app.models.base import Base
+
 
 class FaqCategory(Base):
     __tablename__ = 'faq_categories'
 
     id = Column(Integer, primary_key=True, index=True)
     title = Column(Text, nullable=False)
-    user_group_id = Column(Integer, ForeignKey('user_group.id'), nullable=True)
     express = Column(Boolean, nullable=True, default=False)
 
     faqs = relationship('Faq', back_populates='category', cascade='all, delete-orphan')
-    user_group = relationship('UserGroup')
+    accesses = relationship('FaqCategoryAccess', back_populates='faq_category', cascade='all, delete-orphan')
+
+    @property
+    def user_group_ids(self) -> list[int]:
+        return [access.user_group_id for access in self.accesses]

--- a/navuchai_api/app/models/faq_category_access.py
+++ b/navuchai_api/app/models/faq_category_access.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Integer, ForeignKey
+from sqlalchemy.orm import relationship
+
+from app.models.base import Base
+
+
+class FaqCategoryAccess(Base):
+    __tablename__ = "faq_category_access"
+
+    id = Column(Integer, primary_key=True, index=True)
+    faq_category_id = Column(Integer, ForeignKey("faq_categories.id", ondelete="CASCADE"), nullable=False)
+    user_group_id = Column(Integer, ForeignKey("user_group.id", ondelete="CASCADE"), nullable=False)
+
+    faq_category = relationship("FaqCategory", back_populates="accesses")
+    user_group = relationship("UserGroup")

--- a/navuchai_api/app/schemas/faq_category.py
+++ b/navuchai_api/app/schemas/faq_category.py
@@ -1,10 +1,9 @@
-from datetime import datetime
 from pydantic import BaseModel
 
 
 class FaqCategoryBase(BaseModel):
     title: str
-    user_group_id: int | None = None
+    user_group_ids: list[int] | None = None
     express: bool | None = False
 
 
@@ -14,7 +13,7 @@ class FaqCategoryCreate(FaqCategoryBase):
 
 class FaqCategoryUpdate(BaseModel):
     title: str | None = None
-    user_group_id: int | None = None
+    user_group_ids: list[int] | None = None
     express: bool | None = None
 
 


### PR DESCRIPTION
## Summary
- allow FAQ categories to link with multiple user groups
- expose user_group_ids in FAQ category schemas and routes
- migrate database to new faq_category_access join table

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_689b01d5bcc083228f117109d4fc1763