### PR TITLE
Fix MissingGreenlet in module listing and extend FAQ admin endpoints

### DIFF
--- a/navuchai_api/app/crud/__init__.py
+++ b/navuchai_api/app/crud/__init__.py
@@ -20,11 +20,17 @@ from .course import (
 )
 from .module import create_module, get_module, update_module, delete_module, get_modules_by_course, get_modules_with_lessons_by_course, create_module_for_course
 from .lesson import create_lesson, get_lesson, update_lesson, delete_lesson, get_lessons_by_module, create_lesson_for_module
-from .enrollment import enroll_user, unenroll_user, get_user_courses
+from .enrollment import enroll_user, unenroll_user, get_user_courses, get_all_user_courses
 from .result import get_analytics_user_performance
 from .analytics import get_analytics_data_by_view, get_column_mapping, get_sheet_name, get_filename
 from .lesson import create_lesson, get_lesson, update_lesson, delete_lesson, get_lessons_by_module, create_lesson_for_module, complete_lesson, get_module_progress, get_course_progress
-from .enrollment import enroll_user, unenroll_user, get_user_courses, user_enrolled
+from .enrollment import (
+    enroll_user,
+    unenroll_user,
+    get_user_courses,
+    get_all_user_courses,
+    user_enrolled,
+)
 from .course_test import (
     create_course_test,
     get_course_tests,
@@ -47,6 +53,7 @@ from .faq import (
     answer_faq,
     increment_faq_hits,
     get_new_answers_count,
+    get_new_answers_counts,
 )
 from .user_group import (
     create_group,

--- a/navuchai_api/app/crud/enrollment.py
+++ b/navuchai_api/app/crud/enrollment.py
@@ -27,6 +27,11 @@ async def get_user_courses(db: AsyncSession, user_id: int):
     return result.scalars().all()
 
 
+async def get_all_user_courses(db: AsyncSession):
+    result = await db.execute(select(CourseEnrollment))
+    return result.scalars().all()
+
+
 async def user_enrolled(db: AsyncSession, course_id: int, user_id: int) -> bool:
     result = await db.execute(
         select(CourseEnrollment).where(

--- a/navuchai_api/app/crud/faq.py
+++ b/navuchai_api/app/crud/faq.py
@@ -1,4 +1,5 @@
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import update as sql_update
@@ -83,4 +84,21 @@ async def get_new_answers_count(db: AsyncSession, user_id: int) -> int:
         return res.scalar_one()
     except SQLAlchemyError as e:
         raise DatabaseException(f"Ошибка при получении количества новых ответов: {str(e)}")
+
+
+async def get_new_answers_counts(db: AsyncSession) -> list[dict[str, int]]:
+    try:
+        res = await db.execute(
+            select(Faq.owner_id, func.count())
+            .where(Faq.has_new_answer == True)
+            .group_by(Faq.owner_id)
+        )
+        return [
+            {"user_id": row[0], "count": row[1]}
+            for row in res.all()
+        ]
+    except SQLAlchemyError as e:
+        raise DatabaseException(
+            f"Ошибка при получении количества новых ответов для пользователей: {str(e)}"
+        )
 

--- a/navuchai_api/app/routes/courses.py
+++ b/navuchai_api/app/routes/courses.py
@@ -184,7 +184,8 @@ async def list_course_modules(
         raise HTTPException(status_code=403, detail="Нет доступа к курсу")
     modules = await get_modules_by_course(db, course_id)
     for module in modules:
-        module.lessons = await get_lessons_by_module(
+        # Bypass SQLAlchemy relationship assignment to avoid async lazy-loading
+        module.__dict__["lessons"] = await get_lessons_by_module(
             db, module.id, user.id, load_content=False
         )
     if modules:

--- a/navuchai_api/app/routes/enrollment.py
+++ b/navuchai_api/app/routes/enrollment.py
@@ -1,9 +1,17 @@
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies import get_db
-from app.crud import enroll_user, unenroll_user, get_user_courses, authorized_required, get_current_user, \
-    admin_moderator_required
+from app.crud import (
+    enroll_user,
+    unenroll_user,
+    get_user_courses,
+    get_all_user_courses,
+    authorized_required,
+    get_current_user,
+    admin_moderator_required,
+)
 from app.models import User
+from app.schemas.course_enrollment import CourseEnrollmentBase
 
 router = APIRouter(prefix="/api/courses", tags=["Enrollment"])
 
@@ -28,3 +36,12 @@ async def unenroll(course_id: int, user_id: int, db: AsyncSession = Depends(get_
 @router.get("/users/{user_id}/courses/")
 async def user_courses(user_id: int, db: AsyncSession = Depends(get_db)):
     return await get_user_courses(db, user_id)
+
+
+@router.get(
+    "/users/courses/",
+    response_model=list[CourseEnrollmentBase],
+    dependencies=[Depends(admin_moderator_required)],
+)
+async def all_user_courses(db: AsyncSession = Depends(get_db)):
+    return await get_all_user_courses(db)

--- a/navuchai_api/app/routes/faq.py
+++ b/navuchai_api/app/routes/faq.py
@@ -9,6 +9,7 @@ from app.crud import (
     answer_faq,
     increment_faq_hits,
     get_new_answers_count,
+    get_new_answers_counts,
     admin_moderator_required,
     authorized_required,
     get_current_user,
@@ -16,7 +17,7 @@ from app.crud import (
     is_user_in_group,
 )
 from app.dependencies import get_db
-from app.schemas import FaqCreate, FaqAnswerUpdate, FaqInDB
+from app.schemas import FaqCreate, FaqAnswerUpdate, FaqInDB, NewAnswersCount
 from app.exceptions import DatabaseException
 from app.models import User
 
@@ -128,4 +129,17 @@ async def new_answers_count_route(
         return await get_new_answers_count(db, user.id)
     except SQLAlchemyError:
         raise DatabaseException("Ошибка при получении количества новых ответов")
+
+
+@router.get("/new-answers/count/all/", response_model=list[NewAnswersCount])
+async def new_answers_count_all_route(
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(admin_moderator_required),
+):
+    try:
+        return await get_new_answers_counts(db)
+    except SQLAlchemyError:
+        raise DatabaseException(
+            "Ошибка при получении количества новых ответов для пользователей"
+        )
 

--- a/navuchai_api/app/schemas/__init__.py
+++ b/navuchai_api/app/schemas/__init__.py
@@ -6,7 +6,7 @@ from .user_auth import Token, UserLogin, UserOut
 from .role import RoleBase
 from .course_test import CourseTestBase, CourseTestCreate
 from .module_test import ModuleTestBase, ModuleTestCreate
-from .faq import FaqCreate, FaqAnswerUpdate, FaqInDB
+from .faq import FaqCreate, FaqAnswerUpdate, FaqInDB, NewAnswersCount
 from .faq_category import FaqCategoryCreate, FaqCategoryUpdate, FaqCategoryInDB
 from .test_group_access import TestGroupAccessCreate, TestGroupAccessUpdate, TestGroupAccessResponse
 from .test_access import DeleteTestAccessByTestGroupRequest

--- a/navuchai_api/app/schemas/faq.py
+++ b/navuchai_api/app/schemas/faq.py
@@ -37,3 +37,8 @@ class FaqAnswerUpdate(BaseModel):
 
 class FaqInDB(FaqBase):
     pass
+
+
+class NewAnswersCount(BaseModel):
+    user_id: int
+    count: int


### PR DESCRIPTION
## Summary
- avoid async lazy-load by assigning lessons directly on course modules
- expose aggregated FAQ new-answer counts for admin use
- allow admins to retrieve the entire course enrollment table for FAQ access management

## Testing
- `python -m py_compile navuchai_api/app/routes/courses.py navuchai_api/app/crud/faq.py navuchai_api/app/routes/faq.py navuchai_api/app/schemas/faq.py navuchai_api/app/schemas/__init__.py navuchai_api/app/crud/enrollment.py navuchai_api/app/routes/enrollment.py navuchai_api/app/crud/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_689b0c38801c8322b9d752b7c2243a95