### PR TITLE
Support page ranges in topic PDF splitting

### DIFF
--- a/navuchai_api/app/crud/topic.py
+++ b/navuchai_api/app/crud/topic.py
@@ -1,0 +1,214 @@
+from collections import defaultdict
+from io import BytesIO
+import re
+from typing import Dict, Iterable, List
+
+import boto3
+from botocore.client import Config
+from botocore.exceptions import ClientError
+from pypdf import PdfReader, PdfWriter
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.config import MINIO_ACCESS_KEY, MINIO_BUCKET_NAME, MINIO_REGION, MINIO_SECRET_KEY, MINIO_URL, MINIO_URL_SERT
+from app.exceptions import BadRequestException, DatabaseException, NotFoundException
+from app.models.file import File
+from app.models.topic import Topic, TopicTag
+from app.schemas.file import FileCreate
+from app.crud.file import create_file
+
+s3 = boto3.client(
+    "s3",
+    endpoint_url=MINIO_URL,
+    aws_access_key_id=MINIO_ACCESS_KEY,
+    aws_secret_access_key=MINIO_SECRET_KEY,
+    config=Config(signature_version="s3v4"),
+    region_name=MINIO_REGION,
+)
+
+
+async def _get_or_create_topic(db: AsyncSession, name: str) -> Topic:
+    stmt = select(Topic).where(func.lower(Topic.name) == name.lower())
+    result = await db.execute(stmt)
+    topic = result.scalar_one_or_none()
+    if topic:
+        return topic
+    topic = Topic(name=name)
+    db.add(topic)
+    await db.flush()
+    return topic
+
+
+async def _get_or_create_tags(db: AsyncSession, tag_names: List[str]) -> List[TopicTag]:
+    unique = {tag.strip() for tag in tag_names if tag and tag.strip()}
+    if not unique:
+        return []
+    stmt = select(TopicTag).where(func.lower(TopicTag.name).in_({tag.lower() for tag in unique}))
+    result = await db.execute(stmt)
+    existing = {tag.name.lower(): tag for tag in result.scalars().all()}
+    tags: List[TopicTag] = []
+    for name in unique:
+        key = name.lower()
+        tag = existing.get(key)
+        if not tag:
+            tag = TopicTag(name=name)
+            db.add(tag)
+            await db.flush()
+        tags.append(tag)
+    return tags
+
+
+def _parse_range_tokens(tokens: Iterable[str]) -> List[int]:
+    pages: List[int] = []
+    for token in tokens:
+        part = token.strip()
+        if not part:
+            continue
+        if "-" in part:
+            start_str, end_str = part.split("-", 1)
+            start = int(start_str)
+            end = int(end_str)
+            if start < 1 or end < 1 or start > end:
+                raise BadRequestException(f"Некорректный диапазон страниц: {part}")
+            pages.extend(range(start, end + 1))
+        else:
+            page = int(part)
+            if page < 1:
+                raise BadRequestException(f"Некорректный номер страницы: {part}")
+            pages.append(page)
+    return pages
+
+
+def _pages_from_value(value: object) -> List[int]:
+    if isinstance(value, list):
+        pages: List[int] = []
+        for item in value:
+            pages.extend(_pages_from_value(item))
+        return pages
+    if isinstance(value, str):
+        tokens = value.split(",")
+        return _parse_range_tokens(tokens)
+    if isinstance(value, int):
+        if value < 1:
+            raise BadRequestException(f"Некорректный номер страницы: {value}")
+        return [value]
+    raise BadRequestException("Некорректный формат диапазона страниц")
+
+
+def _group_pages_by_topic(page_topic_map: Dict) -> Dict[str, List[int]]:
+    grouped: Dict[str, List[int]] = defaultdict(list)
+    if all(isinstance(key, (int, str)) and isinstance(value, str) for key, value in page_topic_map.items()):
+        if all(isinstance(key, int) or str(key).isdigit() for key in page_topic_map.keys()):
+            for page_number, topic in page_topic_map.items():
+                page = int(page_number)
+                if not topic:
+                    raise BadRequestException("Имя темы не может быть пустым")
+                grouped[str(topic)].append(page)
+            return grouped
+    for topic_name, ranges in page_topic_map.items():
+        if not topic_name:
+            raise BadRequestException("Имя темы не может быть пустым")
+        pages = _pages_from_value(ranges)
+        grouped[str(topic_name)].extend(pages)
+    return grouped
+
+
+async def split_book_by_topics(
+    db: AsyncSession,
+    creator_id: int,
+    book_pdf: bytes,
+    filename: str,
+    content_type: str,
+    page_topic_map: Dict,
+) -> List[Topic]:
+    if not page_topic_map:
+        raise BadRequestException("page_topic_map не может быть пустым")
+
+    reader = PdfReader(BytesIO(book_pdf))
+    total_pages = len(reader.pages)
+    grouped = _group_pages_by_topic(page_topic_map)
+    topics: List[Topic] = []
+
+    for topic_name, pages in grouped.items():
+        writer = PdfWriter()
+        for page_number in sorted(pages):
+            if page_number < 1 or page_number > total_pages:
+                raise BadRequestException(f"Недопустимый номер страницы: {page_number}")
+            writer.add_page(reader.pages[page_number - 1])
+        buffer = BytesIO()
+        writer.write(buffer)
+        content = buffer.getvalue()
+        safe_topic = re.sub(r"[^A-Za-z0-9._-]+", "_", topic_name)
+        key = f"user_{creator_id}/topics/{safe_topic}_{filename}"
+        try:
+            s3.put_object(
+                Bucket=MINIO_BUCKET_NAME,
+                Key=key,
+                Body=content,
+                ContentLength=len(content),
+                ContentType=content_type,
+            )
+        except ClientError as exc:
+            raise DatabaseException(f"Ошибка при загрузке файла: {str(exc)}") from exc
+
+        url = f"{MINIO_URL_SERT}/{MINIO_BUCKET_NAME}/{key}"
+        file_row = await create_file(
+            db,
+            FileCreate(
+                type=content_type,
+                name=key.split("/")[-1],
+                size=len(content),
+                path=url,
+                provider="minio",
+                creator_id=creator_id,
+            ),
+        )
+
+        topic = await _get_or_create_topic(db, topic_name)
+        if file_row not in topic.files:
+            topic.files.append(file_row)
+        topics.append(topic)
+
+    await db.commit()
+    for topic in topics:
+        await db.refresh(topic)
+    return topics
+
+
+async def add_tags_to_topic(db: AsyncSession, topic_id: int, tags: List[str]) -> Topic:
+    result = await db.execute(
+        select(Topic)
+        .options(selectinload(Topic.tags), selectinload(Topic.files))
+        .where(Topic.id == topic_id)
+    )
+    topic = result.scalar_one_or_none()
+    if not topic:
+        raise NotFoundException("Тема не найдена")
+    new_tags = await _get_or_create_tags(db, tags)
+    existing = {tag.name.lower() for tag in topic.tags}
+    for tag in new_tags:
+        if tag.name.lower() not in existing:
+            topic.tags.append(tag)
+    await db.commit()
+    await db.refresh(topic)
+    return topic
+
+
+async def search_documents_by_tags(db: AsyncSession, tags: List[str]) -> List[Topic]:
+    if not tags:
+        raise BadRequestException("Не указаны теги для поиска")
+    normalized = [tag.strip().lower() for tag in tags if tag and tag.strip()]
+    if not normalized:
+        raise BadRequestException("Не указаны теги для поиска")
+
+    stmt = (
+        select(Topic)
+        .join(Topic.tags)
+        .options(selectinload(Topic.tags), selectinload(Topic.files))
+        .where(func.lower(TopicTag.name).in_(normalized))
+        .group_by(Topic.id)
+        .having(func.count(func.distinct(TopicTag.id)) == len(set(normalized)))
+    )
+    result = await db.execute(stmt)
+    return result.scalars().all()

--- a/navuchai_api/app/main.py
+++ b/navuchai_api/app/main.py
@@ -8,7 +8,7 @@ from app.routes import (
     category, locale, files, role, user_groups,
     test_access, test_status, results, question_type,
     test_access_status, courses, modules, lessons, enrollment, module_tests,
-    test_import, analytics_views, test_group, faq, faq_categories, system_settings, employees, category_access, adaptation, user_activity, folders, documents, calendar
+    test_import, analytics_views, test_group, faq, faq_categories, system_settings, employees, category_access, adaptation, user_activity, folders, documents, calendar, topics
 )
 from app.routes.dashboard_stats import router as dashboard_stats
 from fastapi.middleware.cors import CORSMiddleware
@@ -57,6 +57,7 @@ app.include_router(user_activity)
 app.include_router(folders)
 app.include_router(documents)
 app.include_router(calendar)
+app.include_router(topics)
 app.include_router(dashboard_stats)
 
 

--- a/navuchai_api/app/models/__init__.py
+++ b/navuchai_api/app/models/__init__.py
@@ -45,6 +45,7 @@ from .user_activity import UserActivity
 from .calendar_event import CalendarEvent
 from .calendar_event_attendee import CalendarEventAttendee
 from .calendar_event_reminder import CalendarEventReminder
+from .topic import Topic, TopicTag, topic_tags, topic_files
 
 __all__ = [
     "Base",
@@ -88,5 +89,8 @@ __all__ = [
     "CalendarEvent",
     "CalendarEventAttendee",
     "CalendarEventReminder",
+    "Topic",
+    "TopicTag",
+    "topic_tags",
+    "topic_files",
 ]
-

--- a/navuchai_api/app/models/topic.py
+++ b/navuchai_api/app/models/topic.py
@@ -1,0 +1,42 @@
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Table
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+
+from app.models.base import Base
+
+topic_tags = Table(
+    "topic_tags",
+    Base.metadata,
+    Column("topic_id", Integer, ForeignKey("topic.id", ondelete="CASCADE"), primary_key=True),
+    Column("tag_id", Integer, ForeignKey("topic_tag.id", ondelete="CASCADE"), primary_key=True),
+)
+
+topic_files = Table(
+    "topic_files",
+    Base.metadata,
+    Column("topic_id", Integer, ForeignKey("topic.id", ondelete="CASCADE"), primary_key=True),
+    Column("file_id", Integer, ForeignKey("file.id", ondelete="CASCADE"), primary_key=True),
+)
+
+
+class Topic(Base):
+    __tablename__ = "topic"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), nullable=False, unique=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    tags = relationship("TopicTag", secondary=topic_tags, back_populates="topics", lazy="selectin")
+    files = relationship("File", secondary=topic_files, lazy="selectin")
+
+
+class TopicTag(Base):
+    __tablename__ = "topic_tag"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(120), nullable=False, unique=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    topics = relationship("Topic", secondary=topic_tags, back_populates="tags", lazy="selectin")

--- a/navuchai_api/app/routes/__init__.py
+++ b/navuchai_api/app/routes/__init__.py
@@ -31,6 +31,7 @@ from app.routes.user_activity import router as user_activity_router
 from .folders import router as folders_router
 from .documents import router as documents_router
 from app.routes.calendar import router as calendar_router
+from app.routes.topics import router as topics_router
 
 auth = auth_router
 tests = tests_router
@@ -65,3 +66,4 @@ user_activity = user_activity_router
 folders = folders_router
 documents = documents_router
 calendar = calendar_router
+topics = topics_router

--- a/navuchai_api/app/routes/topics.py
+++ b/navuchai_api/app/routes/topics.py
@@ -1,0 +1,65 @@
+import json
+from typing import List
+
+from fastapi import APIRouter, Depends, File, Form, UploadFile
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud import authorized_required, get_current_user, root_admin_moderator_required
+from app.dependencies import get_db
+from app.models import User
+from app.schemas.topic import TopicResponse, TopicSearchRequest, TopicSplitRequest, TopicTagsUpdateRequest
+from app.crud import topic as topic_crud
+
+router = APIRouter(prefix="/api/topics", tags=["Topics"])
+
+
+@router.post(
+    "/split/",
+    response_model=List[TopicResponse],
+    dependencies=[Depends(root_admin_moderator_required)],
+)
+async def split_book_by_topics(
+    file: UploadFile = File(...),
+    page_topic_map: str = Form(..., alias="pageTopicMap"),
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    content = await file.read()
+    payload = json.loads(page_topic_map)
+    request = TopicSplitRequest(pageTopicMap=payload)
+    topics = await topic_crud.split_book_by_topics(
+        db,
+        user.id,
+        content,
+        file.filename,
+        file.content_type or "application/pdf",
+        request.page_topic_map,
+    )
+    return [TopicResponse.model_validate(topic, from_attributes=True) for topic in topics]
+
+
+@router.post(
+    "/{topic_id}/tags/",
+    response_model=TopicResponse,
+    dependencies=[Depends(root_admin_moderator_required)],
+)
+async def add_tags(
+    topic_id: int,
+    data: TopicTagsUpdateRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    topic = await topic_crud.add_tags_to_topic(db, topic_id, data.tags)
+    return TopicResponse.model_validate(topic, from_attributes=True)
+
+
+@router.post(
+    "/search/",
+    response_model=List[TopicResponse],
+    dependencies=[Depends(authorized_required)],
+)
+async def search_by_tags(
+    data: TopicSearchRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    topics = await topic_crud.search_documents_by_tags(db, data.tags)
+    return [TopicResponse.model_validate(topic, from_attributes=True) for topic in topics]

--- a/navuchai_api/app/schemas/topic.py
+++ b/navuchai_api/app/schemas/topic.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from typing import List
+
+from pydantic import BaseModel, Field
+
+from app.schemas.file import FileInDB
+
+
+class TopicTagResponse(BaseModel):
+    id: int
+    name: str
+
+    class Config:
+        from_attributes = True
+
+
+class TopicResponse(BaseModel):
+    id: int
+    name: str
+    tags: List[TopicTagResponse] = []
+    files: List[FileInDB] = []
+    created_at: datetime = Field(alias="createdAt")
+    updated_at: datetime = Field(alias="updatedAt")
+
+    class Config:
+        from_attributes = True
+        populate_by_name = True
+
+
+class TopicSplitRequest(BaseModel):
+    page_topic_map: dict = Field(alias="pageTopicMap")
+
+    class Config:
+        populate_by_name = True
+
+
+class TopicTagsUpdateRequest(BaseModel):
+    tags: List[str]
+
+
+class TopicSearchRequest(BaseModel):
+    tags: List[str]

--- a/navuchai_api/requirements.txt
+++ b/navuchai_api/requirements.txt
@@ -15,6 +15,7 @@ boto3~=1.34.0
 pandas
 openpyxl
 Pillow>=10.0.0
+pypdf>=4.2.0
 
 # Yandex Cloud ML SDK
 yandex-cloud-ml-sdk


### PR DESCRIPTION
### Motivation

- Allow uploading topic split payloads that specify page ranges (e.g. `"1-3"`) or lists (e.g. `[1, "2-4"]`) so PDFs can be split by contiguous ranges instead of only per-page maps.

### Description

- Relaxed the split request schema by changing `TopicSplitRequest` to accept a flexible `pageTopicMap` (`dict`) in `app/schemas/topic.py`.
- Added range/list parsing helpers (`_parse_range_tokens`, `_pages_from_value`) and updated `_group_pages_by_topic` in `app/crud/topic.py` to accept either per-page maps or topic->range/list mappings and produce a normalized mapping of topic -> page list.
- Kept the `split_book_by_topics` flow but updated its typing to accept the relaxed `page_topic_map` and validate page bounds and topic names before writing and uploading slices.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977698d0e6483229d4dd8c73cec13bf)