### PR TITLE
Use lesson files for topic splitting

### DIFF
--- a/navuchai_api/app/crud/topic.py
+++ b/navuchai_api/app/crud/topic.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from io import BytesIO
 import re
 from typing import Dict, Iterable, List
+from urllib.parse import unquote, urlparse
 
 import boto3
 from botocore.client import Config
@@ -26,6 +27,38 @@ s3 = boto3.client(
     config=Config(signature_version="s3v4"),
     region_name=MINIO_REGION,
 )
+
+
+def _extract_minio_key(file_path: str) -> str:
+    if not file_path:
+        raise BadRequestException("Не указан путь к файлу")
+    parsed = urlparse(file_path)
+    path = unquote(parsed.path or "").lstrip("/")
+    if path.startswith(f"{MINIO_BUCKET_NAME}/"):
+        return path[len(MINIO_BUCKET_NAME) + 1:]
+    if parsed.scheme:
+        return path
+    if file_path.startswith(f"{MINIO_BUCKET_NAME}/"):
+        return file_path[len(MINIO_BUCKET_NAME) + 1:]
+    return file_path
+
+
+def download_file_from_minio(file: File) -> bytes:
+    if not file:
+        raise BadRequestException("Файл для разделения не найден")
+    if file.provider and file.provider != "minio":
+        raise BadRequestException("Файл должен храниться в MinIO")
+    key = _extract_minio_key(file.path)
+    if not key:
+        raise BadRequestException("Некорректный путь к файлу в MinIO")
+    try:
+        response = s3.get_object(Bucket=MINIO_BUCKET_NAME, Key=key)
+    except ClientError as exc:
+        raise DatabaseException(f"Ошибка при получении файла: {str(exc)}") from exc
+    body = response.get("Body")
+    if not body:
+        raise BadRequestException("Не удалось получить содержимое файла")
+    return body.read()
 
 
 async def _get_or_create_topic(db: AsyncSession, name: str) -> Topic:

--- a/navuchai_api/app/routes/topics.py
+++ b/navuchai_api/app/routes/topics.py
@@ -1,11 +1,13 @@
 import json
 from typing import List
 
-from fastapi import APIRouter, Depends, File, Form, UploadFile
+from fastapi import APIRouter, Depends, Form
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.crud import authorized_required, get_current_user, root_admin_moderator_required
+from app.crud.lesson import get_lesson
 from app.dependencies import get_db
+from app.exceptions import BadRequestException
 from app.models import User
 from app.schemas.topic import TopicResponse, TopicSearchRequest, TopicSplitRequest, TopicTagsUpdateRequest
 from app.crud import topic as topic_crud
@@ -19,20 +21,31 @@ router = APIRouter(prefix="/api/topics", tags=["Topics"])
     dependencies=[Depends(root_admin_moderator_required)],
 )
 async def split_book_by_topics(
-    file: UploadFile = File(...),
     page_topic_map: str = Form(..., alias="pageTopicMap"),
+    lesson_id: int = Form(..., alias="lessonId"),
+    file_id: int | None = Form(None, alias="fileId"),
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
-    content = await file.read()
+    lesson = await get_lesson(db, lesson_id)
+    if not lesson.files:
+        raise BadRequestException("В уроке нет файлов для разделения")
+    file = None
+    if file_id is not None:
+        file = next((item for item in lesson.files if item.id == file_id), None)
+        if not file:
+            raise BadRequestException("Файл для разделения не найден в уроке")
+    else:
+        file = lesson.files[0]
+    content = topic_crud.download_file_from_minio(file)
     payload = json.loads(page_topic_map)
     request = TopicSplitRequest(pageTopicMap=payload)
     topics = await topic_crud.split_book_by_topics(
         db,
         user.id,
         content,
-        file.filename,
-        file.content_type or "application/pdf",
+        file.name,
+        file.type or "application/pdf",
         request.page_topic_map,
     )
     return [TopicResponse.model_validate(topic, from_attributes=True) for topic in topics]


### PR DESCRIPTION
### Motivation
- Allow splitting PDFs that are already uploaded to a lesson in MinIO instead of requiring a new upload. 
- Let the client choose which lesson file to split via an optional `fileId` or fallback to the first lesson file. 
- Provide server-side validation and MinIO download so the split operation can operate on existing lesson files.

### Description
- Updated the `POST /api/topics/split/` endpoint to accept `lessonId` and optional `fileId` (removed the `UploadFile` parameter) and to load the lesson via `get_lesson` to find the target file. 
- Added selection and validation logic in the route that raises `BadRequestException` when the lesson has no files or the requested file is not attached to the lesson. 
- Added `_extract_minio_key` and `download_file_from_minio` helpers in `app/crud/topic.py` to resolve MinIO object keys from stored `File.path` values and to fetch file content via `s3.get_object`, with proper error mapping to `BadRequestException`/`DatabaseException`. 
- Adjusted the call to `split_book_by_topics` to pass the downloaded content and use `file.name` and `file.type` as the filename and content type.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697861ad5b4c83228e2bb397af0a9da5)