### PR TITLE
Fix Swagger field names for topic split form

### DIFF
--- a/navuchai_api/app/routes/topics.py
+++ b/navuchai_api/app/routes/topics.py
@@ -21,24 +21,24 @@ router = APIRouter(prefix="/api/topics", tags=["Topics"])
     dependencies=[Depends(root_admin_moderator_required)],
 )
 async def split_book_by_topics(
-    page_topic_map: str = Form(..., alias="pageTopicMap"),
-    lesson_id: int = Form(..., alias="lessonId"),
-    file_id: int | None = Form(None, alias="fileId"),
+    pageTopicMap: str = Form(...),
+    lessonId: int = Form(...),
+    fileId: int | None = Form(None),
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
-    lesson = await get_lesson(db, lesson_id)
+    lesson = await get_lesson(db, lessonId)
     if not lesson.files:
         raise BadRequestException("В уроке нет файлов для разделения")
     file = None
-    if file_id is not None:
-        file = next((item for item in lesson.files if item.id == file_id), None)
+    if fileId is not None:
+        file = next((item for item in lesson.files if item.id == fileId), None)
         if not file:
             raise BadRequestException("Файл для разделения не найден в уроке")
     else:
         file = lesson.files[0]
     content = topic_crud.download_file_from_minio(file)
-    payload = json.loads(page_topic_map)
+    payload = json.loads(pageTopicMap)
     request = TopicSplitRequest(pageTopicMap=payload)
     topics = await topic_crud.split_book_by_topics(
         db,


### PR DESCRIPTION
### Motivation
- Ensure OpenAPI/Swagger exposes the same camelCase form field names (`pageTopicMap`, `lessonId`, `fileId`) that the `/api/topics/split/` handler expects so generated clients submit the correct fields.

### Description
- Replace aliased snake_case form parameters with camelCase parameters in `split_book_by_topics` and update handler references (`lessonId`, `fileId`, `pageTopicMap`) and the `json.loads` call to use the new names.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69786b8f1a6c8322afbd2f0501cc4473)