### PR TITLE
Support lesson `file_links` and download-by-URL for topic splitting

### DIFF
--- a/navuchai_api/app/crud/topic.py
+++ b/navuchai_api/app/crud/topic.py
@@ -1,8 +1,10 @@
 from collections import defaultdict
 from io import BytesIO
+import mimetypes
 import re
 from typing import Dict, Iterable, List
 from urllib.parse import unquote, urlparse
+from urllib.request import urlopen
 
 import boto3
 from botocore.client import Config
@@ -59,6 +61,29 @@ def download_file_from_minio(file: File) -> bytes:
     if not body:
         raise BadRequestException("Не удалось получить содержимое файла")
     return body.read()
+
+
+def download_file_from_link(file_link: str) -> tuple[bytes, str, str]:
+    if not file_link:
+        raise BadRequestException("Не указана ссылка на файл")
+    filename = unquote(urlparse(file_link).path.split("/")[-1] or "")
+    if not filename:
+        raise BadRequestException("Не удалось определить имя файла")
+    content_type = mimetypes.guess_type(filename)[0] or "application/pdf"
+    key = _extract_minio_key(file_link)
+    if key:
+        try:
+            response = s3.get_object(Bucket=MINIO_BUCKET_NAME, Key=key)
+            body = response.get("Body")
+            if body:
+                return body.read(), filename, content_type
+        except ClientError:
+            pass
+    try:
+        with urlopen(file_link) as response:
+            return response.read(), filename, content_type
+    except Exception as exc:
+        raise BadRequestException("Не удалось получить содержимое файла по ссылке") from exc
 
 
 async def _get_or_create_topic(db: AsyncSession, name: str) -> Topic:

--- a/navuchai_api/app/models/lesson.py
+++ b/navuchai_api/app/models/lesson.py
@@ -1,4 +1,5 @@
 from sqlalchemy import Column, Integer, String, Text, ForeignKey, Table
+from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm import relationship
 from app.models.lesson_progress import LessonProgress
 from app.models.base import Base
@@ -23,6 +24,7 @@ class Lesson(Base):
     order = Column(Integer, default=0)
     img_id = Column(Integer, ForeignKey('file.id', ondelete='SET NULL'), nullable=True)
     thumbnail_id = Column(Integer, ForeignKey('file.id', ondelete='SET NULL'), nullable=True)
+    file_links = Column(ARRAY(Text))
     module = relationship('Module', back_populates='lessons')
     tests = relationship('LessonTest', back_populates='lesson', cascade='all, delete-orphan')
     progress = relationship('LessonProgress', back_populates='lesson', cascade='all, delete-orphan')

--- a/navuchai_api/app/routes/topics.py
+++ b/navuchai_api/app/routes/topics.py
@@ -28,24 +28,33 @@ async def split_book_by_topics(
     user: User = Depends(get_current_user),
 ):
     lesson = await get_lesson(db, lessonId)
-    if not lesson.files:
+    if not lesson.files and not lesson.file_links:
         raise BadRequestException("В уроке нет файлов для разделения")
-    file = None
-    if fileId is not None:
-        file = next((item for item in lesson.files if item.id == fileId), None)
-        if not file:
-            raise BadRequestException("Файл для разделения не найден в уроке")
+    content = None
+    filename = None
+    content_type = "application/pdf"
+    if lesson.files:
+        file = None
+        if fileId is not None:
+            file = next((item for item in lesson.files if item.id == fileId), None)
+            if not file:
+                raise BadRequestException("Файл для разделения не найден в уроке")
+        else:
+            file = lesson.files[0]
+        content = topic_crud.download_file_from_minio(file)
+        filename = file.name
+        content_type = file.type or content_type
     else:
-        file = lesson.files[0]
-    content = topic_crud.download_file_from_minio(file)
+        file_link = lesson.file_links[0]
+        content, filename, content_type = topic_crud.download_file_from_link(file_link)
     payload = json.loads(pageTopicMap)
     request = TopicSplitRequest(pageTopicMap=payload)
     topics = await topic_crud.split_book_by_topics(
         db,
         user.id,
         content,
-        file.name,
-        file.type or "application/pdf",
+        filename,
+        content_type,
         request.page_topic_map,
     )
     return [TopicResponse.model_validate(topic, from_attributes=True) for topic in topics]


### PR DESCRIPTION
### Motivation
- Allow lessons that only have external links (not `File` records) to be used as source PDFs for topic splitting.
- Provide a robust download path that can fetch a file from MinIO when a key is present or from an arbitrary URL when given a link.
- Prevent the `/api/topics/split/` endpoint from failing when `lesson.files` is empty but `lesson.file_links` exists.

### Description
- Add `file_links` column to the `Lesson` model as `ARRAY(Text)` to persist external file URLs in `navuchai_api/app/models/lesson.py`.
- Implement `download_file_from_link` in `navuchai_api/app/crud/topic.py` which tries MinIO by key and falls back to `urlopen`, and derives `filename` and `content_type` using `mimetypes`.
- Update the `split_book_by_topics` route in `navuchai_api/app/routes/topics.py` to use `lesson.file_links` when `lesson.files` is empty and to pass `filename` and `content_type` into the existing `split_book_by_topics` CRUD function.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69786ebd06f8832291023de27861efff)