### PR TITLE
Eager-load Topic.files to avoid async lazy-load error during split

### DIFF
--- a/navuchai_api/app/crud/topic.py
+++ b/navuchai_api/app/crud/topic.py
@@ -87,7 +87,11 @@ def download_file_from_link(file_link: str) -> tuple[bytes, str, str]:
 
 
 async def _get_or_create_topic(db: AsyncSession, name: str) -> Topic:
-    stmt = select(Topic).where(func.lower(Topic.name) == name.lower())
+    stmt = (
+        select(Topic)
+        .options(selectinload(Topic.files))
+        .where(func.lower(Topic.name) == name.lower())
+    )
     result = await db.execute(stmt)
     topic = result.scalar_one_or_none()
     if topic:


### PR DESCRIPTION
### Motivation
- Prevent `MissingGreenlet` async lazy-loading errors observed when `split_book_by_topics` accessed `topic.files` and triggered a lazy load outside the expected async context.

### Description
- Add `.options(selectinload(Topic.files))` to the `select(Topic)` query in `_get_or_create_topic` so topic files are eager-loaded when an existing topic is fetched.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69787134a92c8322a6bc30a45c339d0b)