### PR TITLE
Refresh topic.files before membership check to avoid async lazy-load error

### DIFF
--- a/navuchai_api/app/crud/topic.py
+++ b/navuchai_api/app/crud/topic.py
@@ -228,6 +228,7 @@ async def split_book_by_topics(
         )
 
         topic = await _get_or_create_topic(db, topic_name)
+        await db.refresh(topic, attribute_names=["files"])
         if file_row not in topic.files:
             topic.files.append(file_row)
         topics.append(topic)


### PR DESCRIPTION
### Motivation
- Prevent `sqlalchemy.exc.MissingGreenlet` errors when accessing the `files` relationship inside `split_book_by_topics` by ensuring the relationship is loaded before performing membership checks.

### Description
- Added `await db.refresh(topic, attribute_names=["files"])` after obtaining/creating the `Topic` in `navuchai_api/app/crud/topic.py` inside `split_book_by_topics` so the `files` relationship is populated before `if file_row not in topic.files` is evaluated.

### Testing
- Ran the test suite with `pytest`, but collection failed in this environment with `ModuleNotFoundError: No module named 'app'`, so the full automated tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978743c729c832280fb23eadc545083)