### PR TITLE
Ужесточение формата разделения по темам, безопасные имена файлов и авто-теги

### DIFF
--- a/navuchai_api/app/crud/topic.py
+++ b/navuchai_api/app/crud/topic.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from io import BytesIO
 import mimetypes
+import os
 import re
 from typing import Dict, Iterable, List
 from urllib.parse import unquote, urlparse
@@ -160,20 +161,20 @@ def _pages_from_value(value: object) -> List[int]:
 
 def _group_pages_by_topic(page_topic_map: Dict) -> Dict[str, List[int]]:
     grouped: Dict[str, List[int]] = defaultdict(list)
-    if all(isinstance(key, (int, str)) and isinstance(value, str) for key, value in page_topic_map.items()):
-        if all(isinstance(key, int) or str(key).isdigit() for key in page_topic_map.keys()):
-            for page_number, topic in page_topic_map.items():
-                page = int(page_number)
-                if not topic:
-                    raise BadRequestException("Имя темы не может быть пустым")
-                grouped[str(topic)].append(page)
-            return grouped
     for topic_name, ranges in page_topic_map.items():
         if not topic_name:
             raise BadRequestException("Имя темы не может быть пустым")
+        if isinstance(topic_name, int) or str(topic_name).isdigit():
+            raise BadRequestException("Ключи page_topic_map должны быть названиями тем")
         pages = _pages_from_value(ranges)
         grouped[str(topic_name)].extend(pages)
     return grouped
+
+
+def _sanitize_topic_filename(topic_name: str) -> str:
+    cleaned = re.sub(r"\s+", " ", topic_name or "").strip()
+    cleaned = cleaned.replace("/", "_")
+    return cleaned or "topic"
 
 
 async def split_book_by_topics(
@@ -201,8 +202,10 @@ async def split_book_by_topics(
         buffer = BytesIO()
         writer.write(buffer)
         content = buffer.getvalue()
-        safe_topic = re.sub(r"[^A-Za-z0-9._-]+", "_", topic_name)
-        key = f"user_{creator_id}/topics/{safe_topic}_{filename}"
+        topic = await _get_or_create_topic(db, topic_name)
+        extension = os.path.splitext(filename)[1] if filename else ".pdf"
+        topic_filename = f"{_sanitize_topic_filename(topic_name)}{extension}"
+        key = f"user_{creator_id}/topics/{topic.id}/{topic_filename}"
         try:
             s3.put_object(
                 Bucket=MINIO_BUCKET_NAME,
@@ -227,7 +230,10 @@ async def split_book_by_topics(
             ),
         )
 
-        topic = await _get_or_create_topic(db, topic_name)
+        tags = await _get_or_create_tags(db, [topic_name])
+        for tag in tags:
+            if tag not in topic.tags:
+                topic.tags.append(tag)
         await db.refresh(topic, attribute_names=["files"])
         if file_row not in topic.files:
             topic.files.append(file_row)


### PR DESCRIPTION
### Motivation
- Ограничить формат входного `page_topic_map` так, чтобы ключи всегда были названиями тем, а не номерами страниц, и тем самым убрать двусмысленность парсинга. 
- Решить проблему перезаписи файлов при одинаковых именах тем и сохранить читабельные (включая кириллицу) имена файлов в MinIO. 
- Автоматически создавать и привязывать тег с именем темы при разбиении книги.

### Description
- Изменён `_group_pages_by_topic` в `navuchai_api/app/crud/topic.py` для валидации ключей и парсинга значений через ` _pages_from_value`. 
- Добавлена функция `_sanitize_topic_filename` и использование `os.path.splitext` для сохранения расширения файла, а ключ S3 строится как `user_{creator_id}/topics/{topic.id}/{topic_filename}` чтобы избежать коллизий. 
- При создании файла для темы теперь вызывается `_get_or_create_tags(db, [topic_name])` и тег привязывается к `topic.tags`. 
- Добавлен импорт `os` и удалён прежний код, который поддерживал альтернативный числовой формат ключей.

### Testing
- Автоматические тесты не запускались для этого изменения.
- Ручное тестирование/CI не выполнялось в ходе этого PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697880a5a7108322a7b4af5ec4476e34)