### PR TITLE
Eager-load Topic.tags to prevent async lazy-load errors

### DIFF
--- a/navuchai_api/app/crud/topic.py
+++ b/navuchai_api/app/crud/topic.py
@@ -90,7 +90,7 @@ def download_file_from_link(file_link: str) -> tuple[bytes, str, str]:
 async def _get_or_create_topic(db: AsyncSession, name: str) -> Topic:
     stmt = (
         select(Topic)
-        .options(selectinload(Topic.files))
+        .options(selectinload(Topic.files), selectinload(Topic.tags))
         .where(func.lower(Topic.name) == name.lower())
     )
     result = await db.execute(stmt)


### PR DESCRIPTION
### Motivation
- Prevent async lazy-load errors when accessing `Topic.tags` (for example during `split_book_by_topics` tag assignment) by ensuring tags are loaded with the topic.

### Description
- Add `selectinload(Topic.tags)` to the `select(Topic)` statement in `async def _get_or_create_topic(...)` so `Topic.tags` is eagerly loaded alongside `Topic.files`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69788617d4888322a07c518db75daf21)