### PR TITLE
Refresh topic.tags after get/create to avoid async lazy-load error

### DIFF
--- a/navuchai_api/app/crud/topic.py
+++ b/navuchai_api/app/crud/topic.py
@@ -203,6 +203,7 @@ async def split_book_by_topics(
         writer.write(buffer)
         content = buffer.getvalue()
         topic = await _get_or_create_topic(db, topic_name)
+        await db.refresh(topic, attribute_names=["tags"])
         extension = os.path.splitext(filename)[1] if filename else ".pdf"
         topic_filename = f"{_sanitize_topic_filename(topic_name)}{extension}"
         key = f"user_{creator_id}/topics/{topic.id}/{topic_filename}"


### PR DESCRIPTION
### Motivation
- Prevent a SQLAlchemy async lazy-load error (`greenlet_spawn has not been called`) when appending tags to a `Topic` during `split_book_by_topics` by ensuring `topic.tags` is loaded first.

### Description
- Add `await db.refresh(topic, attribute_names=["tags"])` in `split_book_by_topics` (`navuchai_api/app/crud/topic.py`) immediately after `_get_or_create_topic` to eagerly load the topic's tags before modifying them.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697886cb8eb88322bbada72e6ac5684d)