### PR TITLE
Add PDF TOC extraction and restrict contents endpoint to lesson files

### DIFF
--- a/navuchai_api/app/crud/topic.py
+++ b/navuchai_api/app/crud/topic.py
@@ -201,6 +201,60 @@ def _truncate_filename(filename: str, max_length: int = 120) -> str:
     return f"{base[:allowed_base_length]}{extension}"
 
 
+def _parse_table_of_contents_line(line: str) -> tuple[str, str] | None:
+    cleaned = re.sub(r"\.{2,}", " ", line or "")
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    if not cleaned:
+        return None
+    if re.search(r"\bсодержание\b", cleaned, re.IGNORECASE):
+        return None
+    match = re.search(
+        r"^(?P<title>.+?)\s+(?P<pages>\d+(?:\s*[-–—]\s*\d+)?(?:\s*,\s*\d+(?:\s*[-–—]\s*\d+)?)*)\s*$",
+        cleaned,
+    )
+    if not match:
+        return None
+    title = match.group("title").strip(" .-—–")
+    pages = match.group("pages")
+    if not title or not pages:
+        return None
+    pages = re.sub(r"\s*[-–—]\s*", "-", pages)
+    pages = re.sub(r"\s*,\s*", ", ", pages)
+    return title, pages
+
+
+def extract_table_of_contents_from_pdf(book_pdf: bytes) -> Dict[str, str]:
+    if not book_pdf:
+        raise BadRequestException("Файл пустой")
+    reader = PdfReader(BytesIO(book_pdf))
+    pages_text = [(page.extract_text() or "") for page in reader.pages]
+    toc_index = next(
+        (index for index, text in enumerate(pages_text) if re.search(r"\bсодержание\b", text, re.IGNORECASE)),
+        None,
+    )
+    if toc_index is None:
+        return {}
+    results: Dict[str, str] = {}
+    empty_pages = 0
+    for text in pages_text[toc_index:]:
+        lines = text.splitlines()
+        page_matches = 0
+        for line in lines:
+            parsed = _parse_table_of_contents_line(line)
+            if not parsed:
+                continue
+            title, pages = parsed
+            results.setdefault(title, pages)
+            page_matches += 1
+        if results and page_matches == 0:
+            empty_pages += 1
+            if empty_pages >= 2:
+                break
+        else:
+            empty_pages = 0
+    return results
+
+
 async def split_book_by_topics(
     db: AsyncSession,
     creator_id: int,

--- a/navuchai_api/app/routes/topics.py
+++ b/navuchai_api/app/routes/topics.py
@@ -1,7 +1,7 @@
 import json
 from typing import List
 
-from fastapi import APIRouter, Depends, Form
+from fastapi import APIRouter, Depends, Form, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.crud import authorized_required, get_current_user, root_admin_moderator_required
@@ -58,6 +58,37 @@ async def split_book_by_topics(
         request.page_topic_map,
     )
     return [TopicResponse.model_validate(topic, from_attributes=True) for topic in topics]
+
+
+@router.get(
+    "/contents/",
+    response_model=dict[str, str],
+    dependencies=[Depends(authorized_required)],
+)
+async def get_topics_contents(
+    lessonId: int = Query(...),
+    fileId: int | None = Query(None),
+    db: AsyncSession = Depends(get_db),
+):
+    lesson = await get_lesson(db, lessonId)
+    if not lesson.files:
+        raise BadRequestException("В уроке нет файлов для анализа")
+    content = None
+    filename = None
+    content_type = "application/pdf"
+    file = None
+    if fileId is not None:
+        file = next((item for item in lesson.files if item.id == fileId), None)
+        if not file:
+            raise BadRequestException("Файл для анализа не найден в уроке")
+    else:
+        file = lesson.files[0]
+    content = topic_crud.download_file_from_minio(file)
+    filename = file.name
+    content_type = file.type or content_type
+    if content_type != "application/pdf" and not (filename or "").lower().endswith(".pdf"):
+        raise BadRequestException("Файл должен быть PDF")
+    return topic_crud.extract_table_of_contents_from_pdf(content)
 
 
 @router.post(


### PR DESCRIPTION
### Motivation
- Provide a way to extract a PDF lesson's table of contents so clients can auto-detect topics and page intervals. 
- Ensure the new endpoint behaves consistently with other topics methods by always using lesson files stored in MinIO rather than falling back to external links.

### Description
- Added `_parse_table_of_contents_line` and `extract_table_of_contents_from_pdf` in `app/crud/topic.py` to locate a "содержание" page in a PDF, parse TOC lines with a regex, normalize page ranges and return a `Dict[str, str]` mapping titles to page ranges.
- Added `GET /api/topics/contents/` in `app/routes/topics.py` with parameters `lessonId` and optional `fileId`, and wired it to download the lesson file from MinIO and call `extract_table_of_contents_from_pdf`.
- Removed the fallback to lesson link downloads for the `/contents/` endpoint so the file is always taken from the lesson's `files` (MinIO) and validated as PDF; added `Query` import for parameter parsing.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978aa7c50708322b9f0b3fc01fc5c4f)