### PR TITLE
Adjust topics contents page offsets to match PDFs

### DIFF
--- a/navuchai_api/app/crud/topic.py
+++ b/navuchai_api/app/crud/topic.py
@@ -297,6 +297,45 @@ def extract_table_of_contents_from_pdf(book_pdf: bytes) -> Dict[str, str]:
     return results
 
 
+def get_pdf_total_pages(book_pdf: bytes) -> int:
+    if not book_pdf:
+        return 0
+    reader = PdfReader(BytesIO(book_pdf))
+    return len(reader.pages)
+
+
+def build_table_of_contents_items(contents: Dict[str, str], total_pages: int) -> List[Dict[str, int | str]]:
+    parsed: List[Dict[str, int | str]] = []
+    for title, pages in contents.items():
+        tokens = (pages or "").split(",")
+        page_numbers = _parse_range_tokens(tokens)
+        if not page_numbers:
+            continue
+        parsed.append(
+            {
+                "name": title,
+                "page_from": min(page_numbers),
+                "page_to": max(page_numbers),
+            }
+        )
+    if parsed and total_pages > 0:
+        max_toc_page = max(item["page_to"] for item in parsed if isinstance(item["page_to"], int))
+        offset = max(max_toc_page - total_pages, 0)
+        if offset:
+            for item in parsed:
+                if isinstance(item["page_from"], int):
+                    item["page_from"] = max(1, item["page_from"] - offset)
+                if isinstance(item["page_to"], int):
+                    item["page_to"] = max(1, item["page_to"] - offset)
+    for index, item in enumerate(parsed):
+        if index >= len(parsed) - 1:
+            continue
+        next_from = parsed[index + 1]["page_from"]
+        if isinstance(next_from, int) and next_from > item["page_from"]:
+            item["page_to"] = next_from - 1
+    return parsed
+
+
 async def split_book_by_topics(
     db: AsyncSession,
     creator_id: int,

--- a/navuchai_api/app/routes/topics.py
+++ b/navuchai_api/app/routes/topics.py
@@ -9,7 +9,13 @@ from app.crud.lesson import get_lesson
 from app.dependencies import get_db
 from app.exceptions import BadRequestException
 from app.models import User
-from app.schemas.topic import TopicResponse, TopicSearchRequest, TopicSplitRequest, TopicTagsUpdateRequest
+from app.schemas.topic import (
+    TopicContentsItem,
+    TopicResponse,
+    TopicSearchRequest,
+    TopicSplitRequest,
+    TopicTagsUpdateRequest,
+)
 from app.crud import topic as topic_crud
 
 router = APIRouter(prefix="/api/topics", tags=["Topics"])
@@ -62,7 +68,7 @@ async def split_book_by_topics(
 
 @router.get(
     "/contents/",
-    response_model=dict[str, str],
+    response_model=List[TopicContentsItem],
     dependencies=[Depends(authorized_required)],
 )
 async def get_topics_contents(
@@ -92,7 +98,10 @@ async def get_topics_contents(
         content, filename, content_type = topic_crud.download_file_from_link(file_link)
     if content_type != "application/pdf" and not (filename or "").lower().endswith(".pdf"):
         raise BadRequestException("Файл должен быть PDF")
-    return topic_crud.extract_table_of_contents_from_pdf(content)
+    contents = topic_crud.extract_table_of_contents_from_pdf(content)
+    total_pages = topic_crud.get_pdf_total_pages(content)
+    items = topic_crud.build_table_of_contents_items(contents, total_pages)
+    return [TopicContentsItem(name=item["name"], page_from=item["page_from"], page_to=item["page_to"]) for item in items]
 
 
 @router.post(

--- a/navuchai_api/app/schemas/topic.py
+++ b/navuchai_api/app/schemas/topic.py
@@ -40,3 +40,12 @@ class TopicTagsUpdateRequest(BaseModel):
 
 class TopicSearchRequest(BaseModel):
     tags: List[str]
+
+
+class TopicContentsItem(BaseModel):
+    name: str
+    page_from: int = Field(alias="pageFrom")
+    page_to: int = Field(alias="pageTo")
+
+    class Config:
+        populate_by_name = True


### PR DESCRIPTION
### Motivation
- Make TOC page ranges align with actual PDF pagination when documents do not start at page 1 by computing an offset and shifting ranges accordingly.
- Provide a structured response for `GET /api/topics/contents/` as a list of typed items so the frontend receives explicit `pageFrom`/`pageTo` integers instead of raw strings.

### Description
- Added `get_pdf_total_pages(book_pdf: bytes) -> int` helper that returns the actual number of pages in a PDF using `PdfReader`.
- Changed `build_table_of_contents_items(contents: Dict[str, str], total_pages: int)` to accept `total_pages` and compute an `offset = max(max_toc_page - total_pages, 0)`, subtracting that offset from parsed `page_from`/`page_to` values (clamped to `1`) so ranges match the real document pagination, and still adjusting each item's `page_to` based on the next topic start.
- Updated the `GET /api/topics/contents/` route to call `get_pdf_total_pages(content)` and pass the resulting `total_pages` into `build_table_of_contents_items`, and to return a list of `TopicContentsItem` objects instead of a raw dict.
- Added `TopicContentsItem` schema with fields `name`, `pageFrom`, and `pageTo` (aliases: `page_from`/`page_to`) to `app/schemas/topic.py` so the endpoint returns typed items.

### Testing
- No automated tests were executed for these changes (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978c167c4a88322b1b05736af526a82)