### PR TITLE
Adjust TOC page numbers using first-page offset

### DIFF
--- a/navuchai_api/app/crud/topic.py
+++ b/navuchai_api/app/crud/topic.py
@@ -303,8 +303,41 @@ def get_pdf_total_pages(book_pdf: bytes) -> int:
     reader = PdfReader(BytesIO(book_pdf))
     return len(reader.pages)
 
+def _guess_first_page_number(text: str) -> int | None:
+    if not text:
+        return None
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    for line in reversed(lines):
+        cleaned = re.sub(r"[—–-]+", " ", line).strip()
+        if cleaned.isdigit():
+            return int(cleaned)
+    return None
 
-def build_table_of_contents_items(contents: Dict[str, str], total_pages: int) -> List[Dict[str, int | str]]:
+
+def get_pdf_first_page_number(book_pdf: bytes) -> int | None:
+    if not book_pdf:
+        return None
+    reader = PdfReader(BytesIO(book_pdf))
+    if not reader.pages:
+        return None
+    return _guess_first_page_number(reader.pages[0].extract_text() or "")
+
+
+def _apply_page_offset(items: List[Dict[str, int | str]], offset: int) -> None:
+    if offset <= 0:
+        return
+    for item in items:
+        if isinstance(item["page_from"], int):
+            item["page_from"] = max(1, item["page_from"] - offset)
+        if isinstance(item["page_to"], int):
+            item["page_to"] = max(1, item["page_to"] - offset)
+
+
+def build_table_of_contents_items(
+    contents: Dict[str, str],
+    total_pages: int,
+    first_page_number: int | None = None,
+) -> List[Dict[str, int | str]]:
     parsed: List[Dict[str, int | str]] = []
     for title, pages in contents.items():
         tokens = (pages or "").split(",")
@@ -318,15 +351,13 @@ def build_table_of_contents_items(contents: Dict[str, str], total_pages: int) ->
                 "page_to": max(page_numbers),
             }
         )
+    if parsed and first_page_number and first_page_number > 1:
+        _apply_page_offset(parsed, first_page_number - 1)
     if parsed and total_pages > 0:
         max_toc_page = max(item["page_to"] for item in parsed if isinstance(item["page_to"], int))
         offset = max(max_toc_page - total_pages, 0)
         if offset:
-            for item in parsed:
-                if isinstance(item["page_from"], int):
-                    item["page_from"] = max(1, item["page_from"] - offset)
-                if isinstance(item["page_to"], int):
-                    item["page_to"] = max(1, item["page_to"] - offset)
+            _apply_page_offset(parsed, offset)
     for index, item in enumerate(parsed):
         if index >= len(parsed) - 1:
             continue

--- a/navuchai_api/app/routes/topics.py
+++ b/navuchai_api/app/routes/topics.py
@@ -100,7 +100,8 @@ async def get_topics_contents(
         raise BadRequestException("Файл должен быть PDF")
     contents = topic_crud.extract_table_of_contents_from_pdf(content)
     total_pages = topic_crud.get_pdf_total_pages(content)
-    items = topic_crud.build_table_of_contents_items(contents, total_pages)
+    first_page_number = topic_crud.get_pdf_first_page_number(content)
+    items = topic_crud.build_table_of_contents_items(contents, total_pages, first_page_number)
     return [TopicContentsItem(name=item["name"], page_from=item["page_from"], page_to=item["page_to"]) for item in items]
 
 


### PR DESCRIPTION
### Motivation
- PDFs sometimes print a first-page number that is not 1, which makes table-of-contents (TOC) page numbers misaligned with actual PDF pages.
- The TOC extraction must account for the printed first-page number to present correct page ranges to users.
- Reuse a single offset application routine so both first-page and total-page corrections use the same logic.

### Description
- Add `_guess_first_page_number` and `get_pdf_first_page_number` to detect a printed first-page number from the first PDF page text using simple heuristics.
- Introduce `_apply_page_offset` to encapsulate page number offset logic and ensure page numbers do not drop below 1.
- Extend `build_table_of_contents_items` to accept an optional `first_page_number` argument and apply the first-page offset before existing total-page correction logic.
- Wire the new detection into the `/api/topics/contents/` endpoint so the endpoint calls `get_pdf_first_page_number` and passes the value to `build_table_of_contents_items`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978cbf6a3d4832283f47500bdd57faa)