### PR TITLE
Support topic_contents input and serialization in Lesson schemas

### DIFF
--- a/navuchai_api/app/schemas/lesson.py
+++ b/navuchai_api/app/schemas/lesson.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 from app.schemas.lesson_test import LessonTestBase
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict, AliasChoices
 
 from .file import FileInDB
 
@@ -11,8 +11,7 @@ class LessonTopicContentItem(BaseModel):
     page_from: int = Field(alias="pageFrom")
     page_to: int = Field(alias="pageTo")
 
-    class Config:
-        populate_by_name = True
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class LessonBase(BaseModel):
@@ -28,12 +27,13 @@ class LessonBase(BaseModel):
     image: Optional[FileInDB] = None
     thumbnail: Optional[FileInDB] = None
     files: List[FileInDB] = []
-    topic_contents: Optional[List[LessonTopicContentItem]] = Field(default=None, alias="topicContents")
+    topic_contents: Optional[List[LessonTopicContentItem]] = Field(
+        default=None,
+        validation_alias=AliasChoices("topicContents", "topic_contents"),
+    )
     completed: Optional[bool] = None
 
-    class Config:
-        from_attributes = True
-        populate_by_name = True
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
 class LessonCreate(BaseModel):
@@ -46,10 +46,12 @@ class LessonCreate(BaseModel):
     img_id: Optional[int] = Field(default=None, alias="imgId")
     thumbnail_id: Optional[int] = Field(default=None, alias="thumbnailId")
     file_ids: List[int] = []
-    topic_contents: Optional[List[LessonTopicContentItem]] = Field(default=None, alias="topicContents")
+    topic_contents: Optional[List[LessonTopicContentItem]] = Field(
+        default=None,
+        validation_alias=AliasChoices("topicContents", "topic_contents"),
+    )
 
-    class Config:
-        populate_by_name = True
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class LessonResponse(LessonBase):
@@ -68,20 +70,19 @@ class LessonWithoutContent(BaseModel):
     image: Optional[FileInDB] = None
     thumbnail: Optional[FileInDB] = None
     files: List[FileInDB] = []
-    topic_contents: Optional[List[LessonTopicContentItem]] = Field(default=None, alias="topicContents")
+    topic_contents: Optional[List[LessonTopicContentItem]] = Field(
+        default=None,
+        validation_alias=AliasChoices("topicContents", "topic_contents"),
+    )
     completed: Optional[bool] = None
 
-    class Config:
-        from_attributes = True
-        populate_by_name = True
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
 class LessonWithTests(LessonBase):
     tests: List["LessonTestBase"] = []
 
-    class Config:
-        from_attributes = True
-        populate_by_name = True
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
 from pydantic import BaseModel
@@ -98,10 +99,13 @@ class LessonRead(BaseModel):
     thumbnail_id: Optional[int] = Field(default=None, alias="thumbnailId")
     image: Optional[FileInDB] = None
     thumbnail: Optional[FileInDB] = None
-    topic_contents: Optional[List[LessonTopicContentItem]] = Field(default=None, alias="topicContents")
+    topic_contents: Optional[List[LessonTopicContentItem]] = Field(
+        default=None,
+        validation_alias=AliasChoices("topicContents", "topic_contents"),
+    )
     completed: Optional[bool] = None
 
-    model_config = {"from_attributes": True, "populate_by_name": True}
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
 LessonWithTests.model_rebuild()


### PR DESCRIPTION
### Motivation
- Schema changes to Pydantic v2 and previous edits caused `LessonCreate` access to `topic_contents` to break due to alias mismatches.
- The API should accept both `topicContents` (camelCase) from clients and `topic_contents` (snake_case) internally without raising `AttributeError`.
- Responses must continue to expose the field as `topic_contents`, not `topicContents`, to keep server-side naming consistent.

### Description
- Updated `app/schemas/lesson.py` to use Pydantic v2 style `model_config` (`ConfigDict`) and replaced legacy `Config` classes.
- Added `validation_alias=AliasChoices("topicContents", "topic_contents")` to the `topic_contents` field so input accepts both `topicContents` and `topic_contents`.
- Replaced per-class `populate_by_name`/`from_attributes` `Config` blocks with `model_config = ConfigDict(...)` on affected models and converted `LessonTopicContentItem` and other classes accordingly.
- No changes were made to CRUD logic; schema changes ensure `lesson.topic_contents` is available as a snake_case attribute in code.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979cc47985083229f5afddc49da7064)