### PR TITLE
Handle missing topic_contents and add file_links to Lesson payloads

### DIFF
--- a/navuchai_api/app/crud/lesson.py
+++ b/navuchai_api/app/crud/lesson.py
@@ -17,7 +17,8 @@ async def create_lesson(db: AsyncSession, data: LessonCreate):
     # Если хотите, чтобы метод create_lesson тоже вычислял order, добавьте логику по примеру ниже.
     if data.module_id is None:
         raise ValueError("module_id is required")
-    lesson = Lesson(**data.model_dump())
+    lesson_data = data.model_dump(exclude={"file_ids"})
+    lesson = Lesson(**lesson_data)
     db.add(lesson)
     if data.file_ids:
         stmt_files = select(File).where(File.id.in_(data.file_ids))
@@ -57,6 +58,8 @@ async def update_lesson(db: AsyncSession, lesson_id: int, data: LessonCreate):
     lesson.img_id = data.img_id
     lesson.thumbnail_id = data.thumbnail_id
     lesson.topic_contents = data.topic_contents
+    if data.file_links is not None:
+        lesson.file_links = data.file_links
     if data.file_ids:
         stmt_files = select(File).where(File.id.in_(data.file_ids))
         files_result = await db.execute(stmt_files)
@@ -139,7 +142,8 @@ async def create_lesson_for_module(
         video=lesson_in.video,
         img_id=lesson_in.img_id,
         thumbnail_id=lesson_in.thumbnail_id,
-        topic_contents=lesson_in.topic_contents,
+        topic_contents=getattr(lesson_in, "topic_contents", None),
+        file_links=getattr(lesson_in, "file_links", None),
         order=new_order,
         module_id=module_id
     )

--- a/navuchai_api/app/schemas/lesson.py
+++ b/navuchai_api/app/schemas/lesson.py
@@ -27,6 +27,10 @@ class LessonBase(BaseModel):
     image: Optional[FileInDB] = None
     thumbnail: Optional[FileInDB] = None
     files: List[FileInDB] = []
+    file_links: Optional[List[str]] = Field(
+        default=None,
+        validation_alias=AliasChoices("fileLinks", "file_links"),
+    )
     topic_contents: Optional[List[LessonTopicContentItem]] = Field(
         default=None,
         validation_alias=AliasChoices("topicContents", "topic_contents"),
@@ -46,6 +50,10 @@ class LessonCreate(BaseModel):
     img_id: Optional[int] = Field(default=None, alias="imgId")
     thumbnail_id: Optional[int] = Field(default=None, alias="thumbnailId")
     file_ids: List[int] = []
+    file_links: Optional[List[str]] = Field(
+        default=None,
+        validation_alias=AliasChoices("fileLinks", "file_links"),
+    )
     topic_contents: Optional[List[LessonTopicContentItem]] = Field(
         default=None,
         validation_alias=AliasChoices("topicContents", "topic_contents"),
@@ -70,6 +78,10 @@ class LessonWithoutContent(BaseModel):
     image: Optional[FileInDB] = None
     thumbnail: Optional[FileInDB] = None
     files: List[FileInDB] = []
+    file_links: Optional[List[str]] = Field(
+        default=None,
+        validation_alias=AliasChoices("fileLinks", "file_links"),
+    )
     topic_contents: Optional[List[LessonTopicContentItem]] = Field(
         default=None,
         validation_alias=AliasChoices("topicContents", "topic_contents"),
@@ -99,6 +111,10 @@ class LessonRead(BaseModel):
     thumbnail_id: Optional[int] = Field(default=None, alias="thumbnailId")
     image: Optional[FileInDB] = None
     thumbnail: Optional[FileInDB] = None
+    file_links: Optional[List[str]] = Field(
+        default=None,
+        validation_alias=AliasChoices("fileLinks", "file_links"),
+    )
     topic_contents: Optional[List[LessonTopicContentItem]] = Field(
         default=None,
         validation_alias=AliasChoices("topicContents", "topic_contents"),


### PR DESCRIPTION
### Motivation
- Fix an AttributeError raised when creating lessons via the module endpoint because `topic_contents` could be absent on the input model.  
- Accept `fileLinks` in requests/responses so external file links can be submitted alongside `file_ids`.  
- Avoid passing `file_ids` directly into ORM model initialization to prevent unexpected fields being forwarded to `Lesson`.

### Description
- Added `file_links` (with `fileLinks` alias) to lesson schemas in `navuchai_api/app/schemas/lesson.py` for `LessonBase`, `LessonCreate`, `LessonWithoutContent`, and `LessonRead`.  
- When creating a lesson without a module via `create_lesson`, stopped passing `file_ids` into `Lesson` by using `data.model_dump(exclude={"file_ids"})` before model initialization in `navuchai_api/app/crud/lesson.py`.  
- In `update_lesson`, persist `file_links` when provided.  
- In `create_lesson_for_module`, use `getattr(lesson_in, "topic_contents", None)` and `getattr(lesson_in, "file_links", None)` to safely populate `topic_contents` and `file_links` on the new `Lesson` to avoid missing-attribute errors.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979cf5c87408322aa00e1407d85486f)