### PR TITLE
Fix topic split required field check

### DIFF
--- a/navuchai_api/app/routes/topics.py
+++ b/navuchai_api/app/routes/topics.py
@@ -30,7 +30,9 @@ async def _split_topics(
     user: User,
     overwrite: bool = False,
 ) -> List[TopicResponse]:
-    if not page_topic_map or lesson_id is None:
+    if page_topic_map is None or (
+        isinstance(page_topic_map, str) and not page_topic_map.strip()
+    ) or lesson_id is None:
         raise BadRequestException("pageTopicMap и lessonId обязательны")
     lesson = await get_lesson(db, lesson_id)
     if not lesson.files and not lesson.file_links:


### PR DESCRIPTION
### Motivation
- Fix validation in `_split_topics` so that only `pageTopicMap` being `None` or a blank string is rejected while allowing a dict payload, and keep `lessonId` required.

### Description
- Update the required-field check in `_split_topics` to `if page_topic_map is None or (isinstance(page_topic_map, str) and not page_topic_map.strip()) or lesson_id is None:` and raise `BadRequestException` when the condition is met.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979ec71654c8322912d63d2b5a15613)